### PR TITLE
Updated missing classes for some small molecules and GPs

### DIFF
--- a/models/YeastPathways_ACETATEUTIL2-PWY.ttl
+++ b/models/YeastPathways_ACETATEUTIL2-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -226,7 +226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetate utilization - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_AERO-GLYCEROL-CAT-PWY.ttl
+++ b/models/YeastPathways_AERO-GLYCEROL-CAT-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -708,7 +708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ALANINE-DEG3-PWY.ttl
+++ b/models/YeastPathways_ALANINE-DEG3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ALANINE-SYN2-PWY.ttl
+++ b/models/YeastPathways_ALANINE-SYN2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ALL-CHORISMATE-PWY-1.ttl
+++ b/models/YeastPathways_ALL-CHORISMATE-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -47,18 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -81,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,28 +248,6 @@
           <http://model.geneontology.org/CHEBI_29985_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -289,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,40 +314,34 @@
           <http://model.geneontology.org/CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_9fbfbec3-6136-4619-b476-8330b92f00ac_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -395,17 +356,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/d9424e1c-fb88-4cc5-aedb-22537627e624_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,11 +414,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +426,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -476,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -501,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of chorismate metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,13 +596,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,30 +636,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_57972_2.6.1.58-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,23 +651,6 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -716,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,13 +709,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53097> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_e8be52a8-c1c5-40d3-8e9e-476c2c5f336b_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -784,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -855,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -906,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1001,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1032,7 +987,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1044,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,17 +1021,6 @@
           <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1075,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,7 +1131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1192,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1215,7 +1170,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,23 +1206,6 @@
           <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52787> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -1265,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,22 +1230,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_16526_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52787> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1306,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,18 +1275,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_17001>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,8 +1291,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001788>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1350,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1367,7 +1330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1397,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1419,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1439,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1450,23 +1413,12 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1544,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1557,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1584,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,29 +1577,12 @@
           <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,7 +1613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,7 +1632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,6 +1643,17 @@
           <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -1716,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,9 +1682,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/4a3d2895-51ff-4c70-a618-a6882e5d27ae_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1746,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1759,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1773,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1800,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1814,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,7 +1779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1861,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1887,11 +1833,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1845,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
@@ -1911,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1960,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1973,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1990,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,7 +1952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,28 +1972,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53336> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2056,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2069,11 +1998,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2081,7 +2010,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -2089,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2100,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2136,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2149,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2165,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,7 +2110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2214,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2225,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2245,7 +2174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2259,7 +2188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2278,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2331,7 +2260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2340,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2350,11 +2279,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2362,18 +2291,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2381,7 +2310,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f5890a9a-3382-4b93-b34e-b5e2d06e915c_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/H2NEOPTERINALDOL-RXN>
@@ -2403,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2416,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2427,7 +2356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2441,7 +2370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2460,7 +2389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2479,7 +2408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,7 +2427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2514,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2522,17 +2451,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2544,7 +2473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2558,7 +2487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2577,7 +2506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2623,7 +2552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2638,7 +2567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2655,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2668,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2679,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2688,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2706,17 +2635,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2743,29 +2672,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_58702_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2779,7 +2714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2798,7 +2733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,7 +2749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2828,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2844,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2855,7 +2790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2870,7 +2805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,12 +2816,23 @@
           <http://model.geneontology.org/SHIKIMATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2897,7 +2843,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_4a3d2895-51ff-4c70-a618-a6882e5d27ae_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2922,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2942,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2958,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2973,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2989,7 +2946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3011,7 +2968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3030,7 +2987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3046,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3057,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3068,14 +3025,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3085,7 +3039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,7 +3058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3123,7 +3077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3142,7 +3096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3162,17 +3116,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/5d0c01c5-64c5-4186-8053-0b1719e2b521_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/THYMIDYLATESYN-RXN> , <http://model.geneontology.org/RXN3O-9789> , <http://model.geneontology.org/1.5.1.15-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN3O-9789> , <http://model.geneontology.org/1.5.1.15-RXN> , <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3188,7 +3142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3223,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3240,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3256,7 +3210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3267,6 +3221,23 @@
           <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_20502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -3275,7 +3246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,12 +3257,29 @@
           <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_16897_DAHPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3308,7 +3296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3328,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3344,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3382,7 +3370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3408,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3422,7 +3410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3441,7 +3429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3457,7 +3445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3468,7 +3456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3492,11 +3480,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3504,7 +3492,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004834>
@@ -3519,7 +3507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3534,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3551,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3567,7 +3555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3583,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3605,7 +3593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3622,7 +3610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3636,15 +3624,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_58095>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_81676ac3-57ce-4fac-a6d2-123522d3e851_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3652,7 +3651,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/81676ac3-57ce-4fac-a6d2-123522d3e851_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000066_reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -3660,7 +3659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3668,92 +3667,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3763,7 +3676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,12 +3687,115 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/9fbfbec3-6136-4619-b476-8330b92f00ac_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000066_reaction_SHIKIMATE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_3-DEHYDROQUINATE-SYNTHASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3790,7 +3806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3807,7 +3823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3817,9 +3833,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004664> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3840,7 +3853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3856,7 +3869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3876,7 +3889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3892,7 +3905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3912,7 +3925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3929,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3945,7 +3958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,7 +3977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3980,18 +3993,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4006,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4019,7 +4049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4033,7 +4063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4055,7 +4085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4074,7 +4104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4090,7 +4120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4105,7 +4135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4120,7 +4150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4142,7 +4172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4158,7 +4188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4176,7 +4206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4189,7 +4219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4203,7 +4233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4214,17 +4244,6 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -4233,7 +4252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4253,7 +4272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4268,7 +4287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4281,7 +4300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4295,7 +4314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4315,7 +4334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4323,12 +4342,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4353,7 +4375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,7 +4388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4377,7 +4399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4391,7 +4413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4410,7 +4432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4423,17 +4445,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4448,7 +4470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4467,7 +4489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4482,11 +4504,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_e8be52a8-c1c5-40d3-8e9e-476c2c5f336b_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4494,7 +4516,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/e8be52a8-c1c5-40d3-8e9e-476c2c5f336b_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4505,7 +4527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4521,7 +4543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4536,16 +4558,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53305> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4555,7 +4574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4573,7 +4592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4589,7 +4608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4608,7 +4627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4627,7 +4646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4642,7 +4661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4655,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4666,7 +4685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4679,7 +4698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4695,7 +4714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4709,6 +4728,9 @@
 <http://purl.obolibrary.org/obo/GO_0004400>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4718,7 +4740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4726,7 +4748,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
+<http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -4734,14 +4756,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17836>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4752,13 +4771,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53249> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_81676ac3-57ce-4fac-a6d2-123522d3e851_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4768,7 +4798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4779,23 +4809,12 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4806,7 +4825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4817,7 +4836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4831,7 +4850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4842,12 +4861,29 @@
           <http://model.geneontology.org/CHEBI_58866_IGPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/fd360c2c-53a1-4248-8f11-3208734bfd53_RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4857,11 +4893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_fd360c2c-53a1-4248-8f11-3208734bfd53_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4869,7 +4905,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789>
+          <http://model.geneontology.org/fd360c2c-53a1-4248-8f11-3208734bfd53_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -4877,7 +4913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4890,7 +4926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4903,7 +4939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4914,7 +4950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4939,7 +4975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4954,7 +4990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4974,7 +5010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4991,7 +5027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5007,7 +5043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5023,7 +5059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5032,11 +5068,11 @@
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5052,7 +5088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5072,7 +5108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5088,7 +5124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5096,17 +5132,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -5118,7 +5154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5133,7 +5169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5149,7 +5185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5169,7 +5205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5185,7 +5221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5207,7 +5243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5226,7 +5262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5237,6 +5273,9 @@
           <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_57783>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -5245,7 +5284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5256,15 +5295,12 @@
           <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57783>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_456216_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5275,7 +5311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5292,7 +5328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5308,7 +5344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5320,7 +5356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5336,7 +5372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5345,7 +5381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5359,26 +5395,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000002994>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5392,7 +5411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5408,7 +5427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5424,7 +5443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5435,7 +5454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5458,24 +5477,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5485,7 +5493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5501,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5515,7 +5523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5531,7 +5539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5545,7 +5553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5559,7 +5567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5575,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5596,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5609,7 +5617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5624,7 +5632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5645,7 +5653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5661,7 +5669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5677,7 +5685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5696,7 +5704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5712,7 +5720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5727,11 +5735,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_d9424e1c-fb88-4cc5-aedb-22537627e624_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5739,15 +5747,37 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/d9424e1c-fb88-4cc5-aedb-22537627e624_DIHYDROFOLATEREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5764,7 +5794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5783,7 +5813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5797,7 +5827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5813,7 +5843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5828,7 +5858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5845,7 +5875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5858,11 +5888,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/4a3d2895-51ff-4c70-a618-a6882e5d27ae_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29748>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5875,7 +5922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5894,7 +5941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5924,7 +5971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5940,7 +5987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5970,7 +6017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5982,11 +6029,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5994,8 +6041,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6005,7 +6074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6016,17 +6085,6 @@
           <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58359_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6036,7 +6094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6048,11 +6106,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6060,15 +6118,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
+
+<http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000000042> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002233_CHEBI_57701_2.5.1.19-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6076,17 +6154,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58462>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6096,7 +6163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6112,7 +6179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6125,7 +6192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6142,7 +6209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6155,7 +6222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6166,7 +6233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6191,7 +6258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6207,7 +6274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6227,7 +6294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6240,7 +6307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6251,7 +6318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6276,7 +6343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6288,11 +6355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6300,7 +6367,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_16630_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -6308,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6322,7 +6389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6336,7 +6403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6347,6 +6414,9 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/5d0c01c5-64c5-4186-8053-0b1719e2b521_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -6355,7 +6425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6371,7 +6441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6382,7 +6452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6396,7 +6466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6415,7 +6485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6429,7 +6499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6444,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6457,7 +6527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6468,7 +6538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6478,11 +6548,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_5d0c01c5-64c5-4186-8053-0b1719e2b521_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6490,7 +6560,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN>
+          <http://model.geneontology.org/5d0c01c5-64c5-4186-8053-0b1719e2b521_1.5.1.15-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6501,7 +6571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6524,7 +6594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6537,7 +6607,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6548,7 +6629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6573,7 +6654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6589,7 +6670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6600,23 +6681,12 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6626,11 +6696,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6638,7 +6708,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/IGPSYN-RXN>
@@ -6660,7 +6730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6676,7 +6746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6695,7 +6765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6708,17 +6778,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -6730,7 +6800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6744,7 +6814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6763,7 +6833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6779,7 +6849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6790,7 +6860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6799,18 +6869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6821,7 +6880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6832,7 +6891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6847,7 +6906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6863,7 +6922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6883,7 +6942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6899,7 +6958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6917,7 +6976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6930,7 +6989,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6941,7 +7011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6952,7 +7022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6973,7 +7043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6989,12 +7059,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -7007,7 +7074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7028,7 +7095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7044,7 +7111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7063,7 +7130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7093,7 +7160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7115,7 +7182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7131,7 +7198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7151,11 +7218,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7165,7 +7235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7184,7 +7254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7200,7 +7270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7215,7 +7285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7231,7 +7301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7245,7 +7315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7264,7 +7334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7280,28 +7350,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_d9424e1c-fb88-4cc5-aedb-22537627e624_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52843> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7311,7 +7375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7322,16 +7386,22 @@
           <http://model.geneontology.org/CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52843> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7341,7 +7411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7360,7 +7430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7376,7 +7446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7390,7 +7460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7410,7 +7480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7429,7 +7499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7449,7 +7519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7465,7 +7535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7480,9 +7550,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/eba63382-d1c4-4210-86e8-e628da863873_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/e8be52a8-c1c5-40d3-8e9e-476c2c5f336b_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -7490,7 +7560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7511,7 +7581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7524,7 +7594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7541,7 +7611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7560,7 +7630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7576,7 +7646,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7590,7 +7671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7610,7 +7691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7626,7 +7707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7642,7 +7723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7653,7 +7734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7664,29 +7745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7697,7 +7756,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7709,7 +7790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7725,7 +7806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7736,7 +7817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7748,7 +7829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7766,11 +7847,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_106fa5ca-e199-4695-b43e-dc1ea22f496c_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7778,7 +7859,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/106fa5ca-e199-4695-b43e-dc1ea22f496c_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_15377_IGPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -7786,7 +7867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7800,7 +7881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7819,7 +7900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7833,7 +7914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7849,7 +7930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7860,7 +7941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7871,7 +7952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7882,7 +7963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7893,7 +7974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7903,11 +7984,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7915,7 +7996,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -7923,7 +8004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7937,7 +8018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7957,7 +8038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7982,7 +8063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7998,7 +8079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8018,7 +8099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8031,7 +8112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8046,24 +8127,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52935> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_PREPHENATEDEHYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -8074,7 +8144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8090,7 +8160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8106,7 +8176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8121,7 +8191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8132,41 +8202,36 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/e8be52a8-c1c5-40d3-8e9e-476c2c5f336b_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/RXN-10814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004400> ;
@@ -8185,7 +8250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8198,7 +8263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8210,7 +8275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8220,11 +8285,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8232,7 +8297,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
@@ -8244,7 +8309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8257,7 +8322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8268,7 +8333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8286,7 +8351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8305,7 +8370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8321,7 +8386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8336,7 +8401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8344,20 +8409,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GTP-cyclohydrolase I" ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53289> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003849> ;
@@ -8378,7 +8439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8394,7 +8455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8405,12 +8466,12 @@
           <http://model.geneontology.org/CHEBI_58095_RXN-10814>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8421,18 +8482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8443,7 +8493,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002413_PABASYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8458,7 +8519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8471,7 +8532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8485,7 +8546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8496,23 +8557,27 @@
           <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GTP-cyclohydrolase I" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53289> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8523,7 +8588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8540,7 +8605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8554,7 +8619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8569,11 +8634,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8581,7 +8646,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0046417>
@@ -8604,7 +8669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8617,7 +8682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8631,7 +8696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8651,7 +8716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8667,7 +8732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8685,7 +8750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8704,7 +8769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8723,7 +8788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8742,7 +8807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8758,7 +8823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8772,7 +8837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8788,7 +8853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8799,7 +8864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8813,7 +8878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8828,11 +8893,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8840,7 +8905,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -8848,7 +8913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8859,7 +8924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8872,7 +8937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8888,7 +8953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8903,17 +8968,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/81676ac3-57ce-4fac-a6d2-123522d3e851_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8926,7 +8991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8937,7 +9002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8946,7 +9011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8954,29 +9019,40 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" , "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8987,7 +9063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8998,7 +9074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9012,7 +9088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9028,11 +9104,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/81676ac3-57ce-4fac-a6d2-123522d3e851_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -9043,7 +9122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9059,7 +9138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9078,7 +9157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9096,7 +9175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9113,7 +9192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9129,7 +9208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9145,7 +9224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9154,7 +9233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9169,7 +9248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9182,7 +9261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9200,7 +9279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9217,7 +9296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9233,7 +9312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9251,11 +9330,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9263,8 +9342,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
+
+<http://model.geneontology.org/d9424e1c-fb88-4cc5-aedb-22537627e624_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9274,7 +9356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9296,7 +9378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9315,7 +9397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9331,7 +9413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9345,7 +9427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9365,7 +9447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9381,7 +9463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9404,15 +9486,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
+                <http://model.geneontology.org/fd360c2c-53a1-4248-8f11-3208734bfd53_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9434,7 +9516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9453,7 +9535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9472,7 +9554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9488,7 +9570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9500,7 +9582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9516,7 +9598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9530,7 +9612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9546,7 +9628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9558,7 +9640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9575,7 +9657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9595,17 +9677,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/106fa5ca-e199-4695-b43e-dc1ea22f496c_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9624,7 +9706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9642,7 +9724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9659,7 +9741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9672,7 +9754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9685,11 +9767,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9697,7 +9779,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15361_2.6.1.58-RXN>
@@ -9709,7 +9791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9726,7 +9808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9741,16 +9823,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53590> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9760,7 +9839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9771,23 +9850,12 @@
           <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_1ba24bbc-5be4-445d-91bf-9644dbd07352_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9798,18 +9866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9823,7 +9880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9834,22 +9891,16 @@
           <http://model.geneontology.org/IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002333_YPL023C-MONOMER_RXN3O-9789_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9859,7 +9910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9875,7 +9926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9884,7 +9935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9898,7 +9949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9914,7 +9965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9925,7 +9976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9939,7 +9990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9955,7 +10006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9970,7 +10021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9986,7 +10037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10005,7 +10056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10024,7 +10075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10040,7 +10091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10054,7 +10105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10070,7 +10121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10084,7 +10135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10099,11 +10150,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10111,7 +10162,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dd3235f0-4746-4f47-b410-e968dd91f492_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -10119,7 +10170,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_106fa5ca-e199-4695-b43e-dc1ea22f496c_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10130,7 +10192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10145,7 +10207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10158,7 +10220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10173,13 +10235,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52617> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10189,7 +10262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10200,12 +10273,12 @@
           <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_5d0c01c5-64c5-4186-8053-0b1719e2b521_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10220,7 +10293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10236,7 +10309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10252,7 +10325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10263,7 +10336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10274,7 +10347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10299,7 +10372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10312,7 +10385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10327,7 +10400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10343,7 +10416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10361,7 +10434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10374,7 +10447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10388,7 +10461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10404,7 +10477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10416,26 +10489,15 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_9fbfbec3-6136-4619-b476-8330b92f00ac_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10443,7 +10505,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN>
+          <http://model.geneontology.org/9fbfbec3-6136-4619-b476-8330b92f00ac_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
@@ -10455,7 +10517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10470,7 +10532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10486,7 +10548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10502,18 +10564,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10528,7 +10607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10544,7 +10623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10560,7 +10639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10574,7 +10653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10593,7 +10672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10612,7 +10691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10626,7 +10705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10648,7 +10727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10667,7 +10746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10685,11 +10764,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53046> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002762> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "anthranilate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53571> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -10701,7 +10806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10712,27 +10817,12 @@
           <http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
 ] .
 
-<http://model.geneontology.org/YDR354W-MONOMER_PRTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002762> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "anthranilate phosphoribosyl transferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53571> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005600> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10744,7 +10834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10759,11 +10849,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_4a3d2895-51ff-4c70-a618-a6882e5d27ae_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10771,7 +10861,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/4a3d2895-51ff-4c70-a618-a6882e5d27ae_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004902>
@@ -10786,7 +10876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10799,7 +10889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10810,7 +10900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10823,7 +10913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10836,7 +10926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10845,7 +10935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10859,7 +10949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10875,7 +10965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10886,7 +10976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10904,7 +10994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10921,7 +11011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10941,7 +11031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10954,7 +11044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10969,7 +11059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10985,7 +11075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10998,7 +11088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11006,8 +11096,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53094> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11017,7 +11133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11028,27 +11144,12 @@
           <http://model.geneontology.org/YIL116W-MONOMER_RXN-10814_controller>
 ] .
 
-<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53094> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000066_reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11062,7 +11163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11083,7 +11184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11100,7 +11201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11113,7 +11214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11127,7 +11228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11138,40 +11239,12 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11186,24 +11259,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52889> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_3-DEHYDROQUINATE-DEHYDRATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -11214,7 +11276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11222,23 +11284,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11252,7 +11314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11263,12 +11325,12 @@
           <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11285,7 +11347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11298,40 +11360,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD(P)H + H<SUP>+</SUP> &rarr; a 5-methyltetrahydrofolate + NAD(P)<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11345,7 +11396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11354,6 +11405,36 @@
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_18277_PRTRANS-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
 ] .
 
 <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
@@ -11375,41 +11456,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53686> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1>
-] .
-
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -11420,7 +11473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11433,7 +11486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11447,7 +11500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11466,7 +11519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11485,7 +11538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11505,7 +11558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11524,7 +11577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11543,7 +11596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11575,7 +11628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11588,7 +11641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11603,7 +11656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11614,54 +11667,26 @@
 <http://purl.obolibrary.org/obo/GO_0004665>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca8a5a3c-2035-4b2d-9589-16f31cc8653e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ea984e4d-8467-4689-b942-2f8fae7dd73b_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11669,7 +11694,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d9bfd849-fbd3-4bce-89d2-6395e090ca9c_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -11677,7 +11702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11688,7 +11713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11703,7 +11728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11719,7 +11744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11735,7 +11760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11750,7 +11775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11766,7 +11791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11782,7 +11807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11796,7 +11821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11812,7 +11837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11827,24 +11852,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52965> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_1817f982-9134-47ac-b71a-7eeb2ca9d88d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11854,7 +11868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11873,7 +11887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11884,7 +11898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11898,7 +11912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11914,7 +11928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11928,7 +11942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11947,7 +11961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11963,7 +11977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11977,7 +11991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11996,7 +12010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12015,7 +12029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12024,7 +12038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12038,7 +12052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12057,7 +12071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12076,7 +12090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12096,7 +12110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12109,7 +12123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12123,7 +12137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12138,11 +12152,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12150,7 +12164,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
@@ -12162,7 +12176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12170,23 +12184,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002233_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12200,7 +12214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12214,7 +12228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12232,7 +12246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12249,7 +12263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12269,7 +12283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12285,7 +12299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12306,11 +12320,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12318,15 +12332,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
+
+<http://model.geneontology.org/106fa5ca-e199-4695-b43e-dc1ea22f496c_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12337,7 +12365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12348,7 +12376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12365,7 +12393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12384,7 +12412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12400,7 +12428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12414,7 +12442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12430,7 +12458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12439,7 +12467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12456,7 +12484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12472,7 +12500,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12486,7 +12525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12509,7 +12548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12525,7 +12564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12544,7 +12583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12560,7 +12599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12572,7 +12611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12588,7 +12627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12602,7 +12641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12618,7 +12657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12632,7 +12671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12648,7 +12687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12662,7 +12701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12681,7 +12720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12701,7 +12740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12714,7 +12753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12726,7 +12765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12737,12 +12776,23 @@
           <http://model.geneontology.org/reaction_2.6.1.58-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_fd360c2c-53a1-4248-8f11-3208734bfd53_RXN3O-9789_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_TRYPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12751,7 +12801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12765,7 +12815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12785,24 +12835,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52843> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_da9b09e9-6558-4ab5-b250-21fa5ec871b2_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16897> ;
@@ -12813,7 +12852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12826,7 +12865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12840,7 +12879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12859,7 +12898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12870,7 +12909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12882,7 +12921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12904,7 +12943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12924,7 +12963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12937,7 +12976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12948,7 +12987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12962,7 +13001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12982,7 +13021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12998,7 +13037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13021,7 +13060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13035,23 +13074,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_18277>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/47853b41-f278-4702-bc8c-13b8cbf11aba_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
@@ -13060,7 +13082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13079,7 +13101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13109,24 +13131,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -13136,7 +13147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13150,7 +13161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13168,7 +13179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13184,7 +13195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13204,7 +13215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13220,7 +13231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13231,15 +13242,12 @@
           <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/26572fe6-2c51-47b4-87f9-c6a7447c6b53_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13253,7 +13261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13269,7 +13277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13280,7 +13288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13294,7 +13302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13314,7 +13322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13327,7 +13335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13342,7 +13350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13358,7 +13366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13374,7 +13382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13388,7 +13396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13407,7 +13415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13423,7 +13431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13438,7 +13446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13451,7 +13459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13466,7 +13474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13482,7 +13490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13498,7 +13506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13509,7 +13517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13526,7 +13534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13542,7 +13550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13557,7 +13565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13573,7 +13581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13596,7 +13604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13609,18 +13617,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000042>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002333_YKL211C-MONOMER_IGPSYN-RXN_controller_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13634,7 +13645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13650,14 +13661,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/cd05b602-f220-4012-a052-540a611ab56f_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13667,7 +13686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13683,7 +13702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13697,7 +13716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13710,7 +13729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13718,34 +13737,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/CHEBI_16567>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16567>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_YeastPathways_ALL-CHORISMATE-PWY-1/YeastPathways_ALL-CHORISMATE-PWY-1_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13759,7 +13778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13778,7 +13797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13794,7 +13813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13803,7 +13822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13817,7 +13836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13836,7 +13855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13855,7 +13874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13875,32 +13894,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53522> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17836> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -13911,7 +13911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13919,16 +13919,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_e461e4ac-41d5-4afe-b697-1cf81fd4821c_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -13938,7 +13946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13957,7 +13965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13977,9 +13985,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4ab11f31-7618-4233-bb15-e0b8bd8031cf_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/881a3509-2a53-4761-a66a-9491b20ea668_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/9fbfbec3-6136-4619-b476-8330b92f00ac_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -13987,7 +13995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14000,7 +14008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14015,28 +14023,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52787> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -14045,7 +14036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14057,7 +14048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14073,7 +14064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14088,7 +14079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14104,7 +14095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14120,7 +14111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14131,7 +14122,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14145,7 +14147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14161,7 +14163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14186,7 +14188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14208,7 +14210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14230,7 +14232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14240,17 +14242,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16810_RXN-10814>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_b0631a99-002e-4e22-8e11-aecd42e34eff_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -14271,7 +14262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14284,7 +14275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14300,7 +14291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14315,7 +14306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14334,7 +14325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14349,7 +14340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14369,7 +14360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14384,7 +14375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14396,11 +14387,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14408,7 +14399,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -14419,7 +14410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14438,7 +14429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14458,7 +14449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14471,7 +14462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14488,7 +14479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14500,7 +14491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14522,7 +14513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14538,7 +14529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14549,7 +14540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14559,11 +14550,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14571,7 +14562,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c6d98108-6b65-4708-890e-cf31f9c0a05b_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000002534>
@@ -14585,7 +14576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14600,11 +14591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14612,7 +14603,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4f0885f3-8f6c-4763-9ac4-263ede2d2767_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ALL-CHORISMATE-PWY-1>
@@ -14620,7 +14611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14631,7 +14622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_ALLANTOINDEG-PWY.ttl
+++ b/models/YeastPathways_ALLANTOINDEG-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -906,7 +906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1014,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1064,7 +1064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1329,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1560,7 +1560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of allantoin degradation in yeast - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,7 +1616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1650,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,7 +1688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1837,7 +1837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,7 +1889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1926,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1942,7 +1942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1958,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1972,7 +1972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2016,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_ARG-PRO-PWY.ttl
+++ b/models/YeastPathways_ARG-PRO-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine degradation VI (arginase 2 pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -851,7 +851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1183,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1194,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1220,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1343,7 +1343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1449,7 +1449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ARGDEG-YEAST-PWY.ttl
+++ b/models/YeastPathways_ARGDEG-YEAST-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "arginine degradation (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,15 +255,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000050_YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,17 +319,6 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
@@ -341,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,6 +363,21 @@
 <http://purl.obolibrary.org/obo/CHEBI_60039>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_17594_RXN-14903>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17594> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -387,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,26 +445,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/532e2e14-d9a6-46da-9500-174315986017_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004430>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -476,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -519,11 +505,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +517,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903>
+          <http://model.geneontology.org/CHEBI_60039_RXN-14903>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -545,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -677,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -707,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,13 +727,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55393> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_36141_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60039> ;
@@ -758,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,12 +763,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_36141>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_15378_RXN-14116_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,9 +856,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_60039_RXN-14903> , <http://model.geneontology.org/8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_36141_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> , <http://model.geneontology.org/532e2e14-d9a6-46da-9500-174315986017_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_17594_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -895,11 +895,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_532e2e14-d9a6-46da-9500-174315986017_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17594_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/532e2e14-d9a6-46da-9500-174315986017_RXN-14903>
+          <http://model.geneontology.org/CHEBI_17594_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,6 +929,17 @@
           <http://model.geneontology.org/CHEBI_13390_PYRROLINECARBREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17594_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YPL111W-MONOMER_ARGINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006032> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -936,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1044,7 +1055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1240,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1269,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1316,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,7 +1349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,21 +1385,6 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/8c9fad50-d8bc-4f64-8290-c858a187da75_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0004735>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1400,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1436,7 +1432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,7 +1451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1482,11 +1478,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_36141_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36141> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17388>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1499,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1545,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1559,7 +1570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1687,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1702,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1737,7 +1748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1767,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1781,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1851,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1867,7 +1878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1878,23 +1889,12 @@
           <http://model.geneontology.org/YeastPathways_ARGDEG-YEAST-PWY/YeastPathways_ARGDEG-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_532e2e14-d9a6-46da-9500-174315986017_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1931,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1945,7 +1945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2010,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2043,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2090,11 +2090,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_36141_RXN-14903_SGD_PWY_YeastPathways_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2102,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60039_RXN-14903>
+          <http://model.geneontology.org/CHEBI_36141_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2113,7 +2113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2155,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2169,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2240,11 +2240,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17594>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2254,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2309,7 +2312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2342,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2354,7 +2357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2381,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2392,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_ARGSPECAT-PWY.ttl
+++ b/models/YeastPathways_ARGSPECAT-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,18 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ARGSPECAT-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -633,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,6 +633,17 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_ARGSPECAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ARGSYNBSUB-PWY.ttl
+++ b/models/YeastPathways_ARGSYNBSUB-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -251,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -788,7 +788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -886,7 +886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1066,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1119,7 +1119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine biosynthesis II (acetyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1338,7 +1338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,7 +1422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1480,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1508,7 +1508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1583,7 +1583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1613,7 +1613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1643,7 +1643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1701,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1764,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,7 +1797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1808,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1848,7 +1848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,7 +1867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1930,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +1998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2045,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2074,7 +2074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2120,7 +2120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,7 +2136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2164,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2178,7 +2178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2211,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2223,7 +2223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2239,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2254,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,7 +2270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,7 +2306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,7 +2325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2338,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2365,7 +2365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2381,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2396,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2412,7 +2412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2428,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2439,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2464,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2484,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2523,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2551,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2587,7 +2587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2617,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,7 +2633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,7 +2652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2667,7 +2667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2695,7 +2695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2723,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2736,7 +2736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2750,7 +2750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2795,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2809,7 +2809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2838,7 +2838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2854,7 +2854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2907,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2921,7 +2921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,7 +2940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,7 +2956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2969,7 +2969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2986,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3017,7 +3017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3033,7 +3033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3044,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3058,7 +3058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3078,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3097,7 +3097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3133,7 +3133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3147,7 +3147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3166,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3179,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3192,7 +3192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3206,7 +3206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3220,7 +3220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3240,7 +3240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3257,7 +3257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3270,7 +3270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3295,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3311,7 +3311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3327,7 +3327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3341,7 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3361,7 +3361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,7 +3381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3394,7 +3394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3405,7 +3405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3419,7 +3419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3441,7 +3441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3457,7 +3457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3472,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,7 +3485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3496,7 +3496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3507,7 +3507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3518,7 +3518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3529,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3543,7 +3543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3559,7 +3559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3570,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3584,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3599,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3615,7 +3615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3634,7 +3634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3648,7 +3648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3691,7 +3691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3730,7 +3730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3746,7 +3746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3760,7 +3760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3776,7 +3776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3787,7 +3787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3798,7 +3798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3812,7 +3812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3828,7 +3828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3842,7 +3842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3858,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3875,7 +3875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3894,7 +3894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3910,7 +3910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3928,7 +3928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3941,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3955,7 +3955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3982,7 +3982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3993,7 +3993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4007,7 +4007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_ARO-PWY-1.ttl
+++ b/models/YeastPathways_ARO-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,17 +69,6 @@
           <http://model.geneontology.org/YeastPathways_ARO-PWY-1/YeastPathways_ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16897_DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16897> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -89,13 +78,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARO-PWY-1SmallMolecule54781> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_SGD_PWY_YeastPathways_ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chorismate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -669,7 +669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -902,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -952,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1122,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1462,19 +1462,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0009423>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0009423>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1484,7 +1484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,7 +1548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1614,26 +1614,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58394>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YBR249C-MONOMER_DAHPSYN-RXN_controller_SGD_PWY_YeastPathways_ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58394>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1670,7 +1670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,7 +1692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1804,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1823,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1920,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1953,7 +1953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1972,7 +1972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,7 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2003,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2036,7 +2036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2052,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2063,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2088,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2118,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2141,7 +2141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2154,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2169,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2199,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2233,7 +2233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2316,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2349,7 +2349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2394,7 +2394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2416,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2445,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2487,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2500,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2509,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2550,7 +2550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2566,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2580,7 +2580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,6 +2596,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1.ttl
+++ b/models/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-asparagine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -438,24 +438,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-BIOSYNTHESIS-1SmallMolecule72542> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000006349>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -465,7 +454,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASNSYNB-RXN_BFO_0000050_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1/YeastPathways_ASPARAGINE-BIOSYNTHESIS-1_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -836,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,17 +853,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30616_ASNSYNB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -873,13 +862,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPARAGINE-BIOSYNTHESIS-1SmallMolecule72601> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-BIOSYNTHESIS-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -889,7 +889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ASPARAGINE-DEG2-PWY.ttl
+++ b/models/YeastPathways_ASPARAGINE-DEG2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,23 +269,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_15377_ASPARAGHYD-RXN_SGD_PWY_YeastPathways_ASPARAGINE-DEG2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "asparagine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -964,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ASPARTATESYN-PWY.ttl
+++ b/models/YeastPathways_ASPARTATESYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -218,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_ASPBIO-PWY.ttl
+++ b/models/YeastPathways_ASPBIO-PWY.ttl
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -449,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -603,6 +603,21 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000422> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate carboxylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYProtein19444> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_29985_ASPAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -613,28 +628,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYSmallMolecule19324> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000422> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate carboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ASPBIO-PWYProtein19444> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -647,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,40 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ASPBIO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -763,6 +730,39 @@
           <http://model.geneontology.org/CHEBI_15361_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000066_reaction_PYRUVATE-CARBOXYLASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000066_reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_ASPBIO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ASPBIO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -771,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -911,7 +911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_BIOTIN-SYNTHESIS-PWY.ttl
+++ b/models/YeastPathways_BIOTIN-SYNTHESIS-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "biotin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,7 +994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1261,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1349,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1436,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1478,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1673,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1781,7 +1781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1797,7 +1797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1812,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1846,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1863,7 +1863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1879,7 +1879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
+++ b/models/YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
@@ -9,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -892,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -903,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -915,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1388,7 +1388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1427,7 +1427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1525,13 +1525,13 @@
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN> , <http://model.geneontology.org/CHEBI_57287_2-ISOPROPYLMALATESYN-RXN> , <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller> , <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller> ;
+                <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller> , <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-13163> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1581,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1710,7 +1710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1769,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1840,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1854,7 +1854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1997,7 +1997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2022,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2089,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,7 +2105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2146,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2176,7 +2176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2292,7 +2292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2337,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2353,7 +2353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2369,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2386,7 +2386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2416,7 +2416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2446,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2460,7 +2460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2476,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2490,7 +2490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,7 +2506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2518,7 +2518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2547,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2564,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2581,7 +2581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2598,7 +2598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2611,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2625,7 +2625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2643,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2674,7 +2674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2704,7 +2704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2723,7 +2723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2777,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2793,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2806,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2834,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2848,7 +2848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2867,7 +2867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,7 +2883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2897,7 +2897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2928,7 +2928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2944,7 +2944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,7 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2971,7 +2971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2985,7 +2985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3005,7 +3005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3020,7 +3020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3038,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,7 +3057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3073,7 +3073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3084,7 +3084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3098,7 +3098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,7 +3117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3136,7 +3136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3161,7 +3161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3175,7 +3175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3194,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3206,7 +3206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3226,7 +3226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3243,7 +3243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3263,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3276,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3287,7 +3287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3300,7 +3300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3317,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3333,7 +3333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3349,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3358,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3383,7 +3383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3399,7 +3399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3415,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3430,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of branched chain amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3446,7 +3446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3466,7 +3466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3479,7 +3479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3494,7 +3494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3507,7 +3507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3524,7 +3524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3538,7 +3538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3554,7 +3554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3566,7 +3566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3580,7 +3580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3599,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3610,7 +3610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3621,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3636,7 +3636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3652,7 +3652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3671,7 +3671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3687,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3698,7 +3698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3715,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3737,7 +3737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3753,7 +3753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3767,7 +3767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3797,7 +3797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3810,7 +3810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3821,7 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3832,7 +3832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3843,7 +3843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3857,7 +3857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3885,7 +3885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3904,7 +3904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3918,7 +3918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3929,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3943,7 +3943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3959,7 +3959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3972,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3985,7 +3985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3996,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4007,7 +4007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4021,7 +4021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4046,7 +4046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4076,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4089,7 +4089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4103,7 +4103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4122,7 +4122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4142,7 +4142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4155,7 +4155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4166,7 +4166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4177,7 +4177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4194,7 +4194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4210,7 +4210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4221,7 +4221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4232,7 +4232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4246,7 +4246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4264,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4277,7 +4277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4290,7 +4290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4306,7 +4306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4324,7 +4324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4340,7 +4340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4356,7 +4356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4370,7 +4370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4390,7 +4390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4406,7 +4406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4420,7 +4420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4434,7 +4434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4454,7 +4454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4470,7 +4470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4492,7 +4492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4511,7 +4511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4527,7 +4527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4542,7 +4542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4559,7 +4559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4575,7 +4575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4591,7 +4591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4605,7 +4605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4621,7 +4621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4632,7 +4632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4657,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4674,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4687,7 +4687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4704,7 +4704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4720,7 +4720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4733,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4748,7 +4748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4764,7 +4764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4784,7 +4784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4800,7 +4800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4814,7 +4814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4833,7 +4833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4847,7 +4847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4863,7 +4863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4877,7 +4877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4888,6 +4888,17 @@
           <http://model.geneontology.org/CHEBI_15378_ACETOOHBUTSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-30_ACETOOHBUTSYN-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4897,13 +4908,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1Complex55681> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_ACETOOHBUTREDUCTOISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4914,7 +4936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4922,34 +4944,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_57540_RXN-13158_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002234_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROXYMETVALDEHYDRAT-RXN_RO_0002233_CHEBI_49258_ACETOOHBUTREDUCTOISOM-RXN_SGD_PWY_YeastPathways_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4964,7 +4964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_BSUBPOLYAMSYN-PWY.ttl
+++ b/models/YeastPathways_BSUBPOLYAMSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,6 +160,9 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000006273>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57443>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_59789_SAMDECARB-RXN>
@@ -171,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -184,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -195,14 +198,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57443>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermidine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_CITRUL-BIO2-PWY.ttl
+++ b/models/YeastPathways_CITRUL-BIO2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,20 +230,6 @@
 <http://identifiers.org/sgd/S000005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000003666>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:CITRUL-BIO2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57743_ORNCARBAMTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57743> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -253,13 +239,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=CITRUL-BIO2-PWYSmallMolecule22903> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-887_CARBPSYN-RXN_controller_BFO_0000051_SGD_S000003870_CPLX3O-887_component_SGD_PWY_YeastPathways_CITRUL-BIO2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:CITRUL-BIO2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003666>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CARBPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "citrulline biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -851,7 +851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -903,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1014,7 +1014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,7 +1099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1118,7 +1118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_COMPLETE-ARO-PWY-1.ttl
+++ b/models/YeastPathways_COMPLETE-ARO-PWY-1.ttl
@@ -1,13 +1,5 @@
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000001694>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -17,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,8 +20,16 @@
           <http://model.geneontology.org/PRAISOM-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000001694>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57783_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36208> ;
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -459,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +693,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -708,24 +719,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56694> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002333_YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -735,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -862,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1385,7 +1385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1418,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1432,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1621,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1635,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1670,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1684,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1758,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1791,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of aromatic amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1850,7 +1850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1931,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1944,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1971,7 +1971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1991,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2007,7 +2007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2059,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2073,7 +2073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2119,7 +2119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2191,7 +2191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2251,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2280,7 +2280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2332,7 +2332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2386,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2413,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2424,7 +2424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2436,7 +2436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2479,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2494,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2510,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2523,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2539,7 +2539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,18 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2578,7 +2567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,6 +2578,17 @@
           <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_RO_0002234_CHEBI_29888_PRTRANS-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2596,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2609,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2637,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2653,7 +2653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2669,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2702,7 +2702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2717,7 +2717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2750,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2805,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2820,7 +2820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2836,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2855,7 +2855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,7 +2871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2882,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2896,7 +2896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2915,7 +2915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2940,7 +2940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2953,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2972,7 +2972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2991,7 +2991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3024,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3043,7 +3043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3059,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3070,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3079,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3093,7 +3093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3109,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3123,7 +3123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3139,7 +3139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3150,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3192,7 +3192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3207,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3220,7 +3220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3234,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3248,7 +3248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3264,7 +3264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3273,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3284,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3298,7 +3298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,7 +3317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3333,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3344,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3355,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3366,7 +3366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3380,7 +3380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3411,7 +3411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3430,7 +3430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3460,7 +3460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3476,7 +3476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3492,28 +3492,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56751> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/DAHPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003849> ;
@@ -3534,7 +3517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3542,12 +3525,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56751> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000066_reaction_ANTHRANSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3561,7 +3561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3580,7 +3580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3599,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3610,7 +3610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3621,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3635,7 +3635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3654,7 +3654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3673,7 +3673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3692,7 +3692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3712,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3725,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3743,7 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3762,7 +3762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3780,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3797,7 +3797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3813,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3827,7 +3827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3846,7 +3846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3855,7 +3855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3866,7 +3866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3880,7 +3880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3896,7 +3896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3922,7 +3922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3935,7 +3935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3950,7 +3950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3965,7 +3965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3978,7 +3978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3999,7 +3999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4015,7 +4015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4041,30 +4041,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_COMPLETE-ARO-PWY-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16567> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "anthranilate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56892> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4088,7 +4071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4096,12 +4079,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16567> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "anthranilate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56892> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_58866_IGPSYN-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4115,7 +4115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4133,7 +4133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4152,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4169,7 +4169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4188,7 +4188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4207,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4218,7 +4218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4232,7 +4232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4251,7 +4251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4271,7 +4271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4287,7 +4287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4303,7 +4303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4312,7 +4312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4326,7 +4326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4345,7 +4345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4361,13 +4361,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_BFO_0000066_reaction_PREPHENATE-DEHYDROGENASE-NADP+-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4383,7 +4383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4394,7 +4394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4408,7 +4408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4420,7 +4420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4439,7 +4439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4455,7 +4455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4466,7 +4466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4477,7 +4477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4491,7 +4491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4513,7 +4513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4526,7 +4526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4543,7 +4543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4559,7 +4559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4575,7 +4575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4586,7 +4586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4600,7 +4600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4619,7 +4619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4639,7 +4639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4652,7 +4652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4663,7 +4663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4678,7 +4678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4691,7 +4691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4702,7 +4702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4714,7 +4714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4733,7 +4733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4753,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4769,7 +4769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4784,7 +4784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4797,7 +4797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4812,7 +4812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4828,7 +4828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4842,7 +4842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4858,7 +4858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4876,7 +4876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4895,7 +4895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4914,7 +4914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4925,24 +4925,16 @@
           <http://model.geneontology.org/CHEBI_58394_DAHPSYN-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4952,7 +4944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4963,16 +4955,24 @@
           <http://model.geneontology.org/CHEBI_16810_TYROSINE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002234_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SHIKIMATE-5-DEHYDROGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
+] .
 
 <http://model.geneontology.org/CHORISMATE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004107> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4993,7 +4993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5010,7 +5010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5030,7 +5030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5046,7 +5046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5069,7 +5069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5085,7 +5085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5103,7 +5103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5119,7 +5119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5142,7 +5142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5155,7 +5155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5166,7 +5166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5178,7 +5178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5194,7 +5194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5205,7 +5205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5216,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5228,7 +5228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5247,7 +5247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5263,7 +5263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5274,7 +5274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5289,7 +5289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5305,7 +5305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5324,7 +5324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5354,7 +5354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5370,7 +5370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5389,7 +5389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5405,7 +5405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5416,7 +5416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5430,7 +5430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5450,7 +5450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5477,7 +5477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5493,7 +5493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5512,7 +5512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5532,7 +5532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5549,7 +5549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5562,7 +5562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5573,7 +5573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5590,7 +5590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5609,7 +5609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5629,7 +5629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5642,7 +5642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5657,7 +5657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5673,7 +5673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5691,7 +5691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5710,7 +5710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5729,7 +5729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5740,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5754,7 +5754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5768,7 +5768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5784,7 +5784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5795,7 +5795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5806,7 +5806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5830,7 +5830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5846,7 +5846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5865,7 +5865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5880,7 +5880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5893,7 +5893,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5906,7 +5917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5922,7 +5933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5933,17 +5944,6 @@
           <http://model.geneontology.org/reaction_IGPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_YeastPathways_COMPLETE-ARO-PWY-1/YeastPathways_COMPLETE-ARO-PWY-1_SGD_PWY_YeastPathways_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5953,7 +5953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5975,7 +5975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6003,7 +6003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6016,7 +6016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6030,7 +6030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6046,7 +6046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6057,7 +6057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6071,7 +6071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6090,7 +6090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6106,7 +6106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6121,7 +6121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6141,7 +6141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6160,7 +6160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6176,7 +6176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6189,7 +6189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6202,7 +6202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6216,7 +6216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6235,7 +6235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6258,7 +6258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6271,7 +6271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6285,7 +6285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6304,7 +6304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6320,7 +6320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6337,7 +6337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6353,7 +6353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6364,7 +6364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6378,7 +6378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6394,7 +6394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6405,7 +6405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6414,7 +6414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6429,7 +6429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6442,7 +6442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6455,7 +6455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6471,7 +6471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6482,7 +6482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6494,7 +6494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6510,7 +6510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6523,7 +6523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6536,7 +6536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6547,7 +6547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6564,7 +6564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6583,7 +6583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6599,7 +6599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6617,7 +6617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6630,7 +6630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6642,7 +6642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6661,7 +6661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6677,7 +6677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6702,7 +6702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6719,7 +6719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6732,7 +6732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6749,7 +6749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6768,7 +6768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6787,7 +6787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6815,7 +6815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6830,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6847,7 +6847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6860,7 +6860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6874,7 +6874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6893,7 +6893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6912,7 +6912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6932,7 +6932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6951,7 +6951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6984,7 +6984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7000,7 +7000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7016,7 +7016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7039,7 +7039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7052,7 +7052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7066,7 +7066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7085,7 +7085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7104,7 +7104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7118,7 +7118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7134,7 +7134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7145,7 +7145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_CYSTEINE-SYN2-PWY.ttl
+++ b/models/YeastPathways_CYSTEINE-SYN2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "cysteine biosynthesis from homocysteine - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,7 +581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_DENOVOPURINE2-PWY.ttl
+++ b/models/YeastPathways_DENOVOPURINE2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,11 +258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002333_YKL067W-MONOMER_GDPKIN-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -956,11 +956,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_b32500b3-372a-448c-9101-734159d5353b_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -968,7 +968,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN>
+          <http://model.geneontology.org/b32500b3-372a-448c-9101-734159d5353b_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1015,35 +1015,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_456215_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1161,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1227,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1271,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,7 +1273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1329,7 +1312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1385,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1398,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,6 +1466,17 @@
           <http://model.geneontology.org/CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_b32500b3-372a-448c-9101-734159d5353b_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
@@ -1491,7 +1485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1584,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1597,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1608,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1681,7 +1675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,7 +1694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1722,7 +1716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,7 +1773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1843,11 +1837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_6714c94e-8574-436d-a0b1-ccf47db877b5_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1855,7 +1849,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/6714c94e-8574-436d-a0b1-ccf47db877b5_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
@@ -1863,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1878,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1906,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1934,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,18 +1941,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_CHEBI_58467_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2038,7 +2060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2058,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2074,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2093,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2109,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2120,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2134,7 +2156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2164,7 +2186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2217,7 +2239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2239,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2258,7 +2280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2274,7 +2296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2300,9 +2322,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/CHEBI_134413_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/b32500b3-372a-448c-9101-734159d5353b_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2310,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2329,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2362,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2375,18 +2397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_f6bb3135-3f7e-43e9-91ac-8243cd646d2d_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,7 +2430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2434,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2450,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2465,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2499,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2515,7 +2526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2535,7 +2546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2548,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2561,7 +2572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2577,7 +2588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2611,7 +2622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2630,7 +2641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2646,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2660,7 +2671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2682,7 +2693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,7 +2715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2735,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2748,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2757,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2769,7 +2780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2785,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2799,7 +2810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2818,7 +2829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2856,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2869,7 +2880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2883,7 +2894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2894,7 +2905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2928,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2941,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2952,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2965,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2978,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2991,7 +3002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3004,7 +3015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3015,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3029,7 +3040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3059,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3072,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3090,7 +3101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3103,18 +3114,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3127,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3154,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3167,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3181,7 +3195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3216,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3227,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3240,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3253,7 +3267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3267,7 +3281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3305,7 +3319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3321,7 +3335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3333,7 +3347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3352,7 +3366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3372,7 +3386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3399,7 +3413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,7 +3432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3448,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3464,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3481,7 +3495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3495,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3506,7 +3520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3515,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3530,7 +3544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3543,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3558,24 +3572,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57335> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3586,13 +3589,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57729> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004727>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3606,7 +3620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3628,7 +3642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3647,7 +3661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3666,7 +3680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3685,7 +3699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,7 +3719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3732,11 +3746,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3744,7 +3758,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_GART-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
@@ -3755,7 +3769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3772,7 +3786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,7 +3802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3799,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3813,7 +3827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3843,7 +3857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3856,7 +3870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3867,7 +3881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3881,7 +3895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3900,7 +3914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3916,7 +3930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3927,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3938,7 +3952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3949,18 +3963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3974,7 +3977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3990,7 +3993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4001,7 +4004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4015,7 +4018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4024,7 +4027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4038,7 +4041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4058,7 +4061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4074,7 +4077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4090,7 +4093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4104,7 +4107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4124,7 +4127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4137,7 +4140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4157,7 +4160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4173,7 +4176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4187,7 +4190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4206,7 +4209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4226,7 +4229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4243,7 +4246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4268,7 +4271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4284,7 +4287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,7 +4303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4311,7 +4314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4323,7 +4326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4343,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4359,7 +4362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4375,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4386,7 +4389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4397,7 +4400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4412,7 +4415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4428,7 +4431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4439,7 +4442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4452,7 +4455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4468,7 +4471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4485,7 +4488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4505,7 +4508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4522,7 +4525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4538,7 +4541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4560,7 +4563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4579,7 +4582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4591,7 +4594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4607,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4621,7 +4624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4640,7 +4643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4659,7 +4662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4678,7 +4681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4697,7 +4700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4711,7 +4714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4730,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4744,7 +4747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4763,7 +4766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4777,7 +4780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4797,7 +4800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4813,7 +4816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4830,7 +4833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4850,7 +4853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4867,7 +4870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4894,7 +4897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4910,7 +4913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4935,7 +4938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4948,7 +4951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4961,7 +4964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4977,7 +4980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4996,7 +4999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5016,7 +5019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5032,7 +5035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5052,7 +5055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5065,7 +5068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5079,7 +5082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5095,7 +5098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5109,7 +5112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5129,7 +5132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5145,7 +5148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5161,7 +5164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5173,7 +5176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5189,7 +5192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5203,7 +5206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5223,7 +5226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5238,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5260,7 +5263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5271,7 +5274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5282,7 +5285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5293,18 +5296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5318,7 +5310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5334,7 +5326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5345,7 +5337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5356,7 +5348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5367,7 +5359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5381,7 +5373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5400,7 +5392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5419,7 +5411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5435,7 +5427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5446,7 +5438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5457,7 +5449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5474,7 +5466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5494,7 +5486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5510,7 +5502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5529,7 +5521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5549,7 +5541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5565,7 +5557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5584,7 +5576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5620,7 +5612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5637,7 +5629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5650,7 +5642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5665,11 +5657,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/b32500b3-372a-448c-9101-734159d5353b_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -5684,7 +5693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5698,7 +5707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5709,7 +5718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5720,7 +5729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5729,7 +5738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5741,7 +5750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5756,7 +5765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5769,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5786,7 +5795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5797,7 +5806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5811,7 +5820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5830,7 +5839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5846,7 +5855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5860,7 +5869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5879,7 +5888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5898,7 +5907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5917,7 +5926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5936,7 +5945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5952,7 +5961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5966,7 +5975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5982,7 +5991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5994,7 +6003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6012,7 +6021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6039,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6055,7 +6064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6066,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6077,7 +6086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6088,7 +6097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6099,7 +6108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6110,7 +6119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6121,7 +6130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6132,7 +6141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6146,7 +6155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6162,7 +6171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6173,7 +6182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6184,7 +6193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6197,7 +6206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6217,7 +6226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6236,7 +6245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6251,11 +6260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6263,7 +6272,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6274,7 +6283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6293,7 +6302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6313,7 +6322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6329,7 +6338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6348,7 +6357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6364,7 +6373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6378,7 +6387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6397,7 +6406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6411,7 +6420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6430,7 +6439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6446,7 +6455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6460,7 +6469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6480,7 +6489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6493,35 +6502,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002333_YMR120C-MONOMER_AICARTRANSFORM-RXN_controller_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6545,7 +6537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6558,7 +6550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6569,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6586,7 +6578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6602,7 +6594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6613,7 +6605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6624,7 +6616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6639,7 +6631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6655,7 +6647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6672,7 +6664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6688,7 +6680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6702,7 +6694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6718,7 +6710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6730,7 +6722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6749,7 +6741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6765,7 +6757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6779,7 +6771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6798,7 +6790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6818,7 +6810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6835,7 +6827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6848,7 +6840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6862,7 +6854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6884,7 +6876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6906,7 +6898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6922,7 +6914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6933,7 +6925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6951,7 +6943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6968,7 +6960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6984,7 +6976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7006,7 +6998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7021,7 +7013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7037,7 +7029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7048,12 +7040,23 @@
           <http://model.geneontology.org/CHEBI_29991_SAICARSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_6714c94e-8574-436d-a0b1-ccf47db877b5_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7062,7 +7065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7076,7 +7079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7092,7 +7095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7106,7 +7109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7125,7 +7128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7139,7 +7142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7158,7 +7161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7174,7 +7177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7189,7 +7192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7211,7 +7214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7230,7 +7233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7248,7 +7251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7264,7 +7267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7280,7 +7283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7294,7 +7297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7314,28 +7317,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57939> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7346,7 +7332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7365,7 +7351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7374,7 +7360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7385,7 +7371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7398,7 +7384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7409,7 +7395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7423,7 +7409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7442,7 +7428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7462,7 +7448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7478,7 +7464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7508,7 +7494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7524,7 +7510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7546,7 +7532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7562,7 +7548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7571,7 +7557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7583,7 +7569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7602,7 +7588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7618,7 +7604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7635,7 +7621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7654,7 +7640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7674,7 +7660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7695,7 +7681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7712,7 +7698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7727,7 +7713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7740,7 +7726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7755,7 +7741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7771,7 +7757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7787,7 +7773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7802,7 +7788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7815,7 +7801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7824,7 +7810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7838,7 +7824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7854,7 +7840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7865,7 +7851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7876,7 +7862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7887,7 +7873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7901,7 +7887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7917,7 +7903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7929,7 +7915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7948,7 +7934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7966,7 +7952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -7983,7 +7969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8000,7 +7986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8017,7 +8003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8033,7 +8019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8049,7 +8035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8063,7 +8049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8083,7 +8069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8099,7 +8085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8118,7 +8104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8137,7 +8123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8157,7 +8143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8173,7 +8159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8193,7 +8179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8213,7 +8199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8226,7 +8212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8237,7 +8223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8248,7 +8234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8266,7 +8252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8286,9 +8272,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/8c46835b-50a2-4f68-a701-369ace424509_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/6714c94e-8574-436d-a0b1-ccf47db877b5_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -8296,7 +8282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8321,7 +8307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8334,7 +8320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8359,7 +8345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8375,7 +8361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8391,7 +8377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8402,7 +8388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8413,7 +8399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8428,7 +8414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8444,7 +8430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8458,7 +8444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8477,7 +8463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8491,7 +8477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8510,7 +8496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8526,7 +8512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8540,7 +8526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8559,7 +8545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8578,7 +8564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8597,7 +8583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8616,7 +8602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8636,7 +8622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8649,7 +8635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8662,7 +8648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8675,7 +8661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8689,7 +8675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8709,7 +8695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8722,7 +8708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8747,7 +8733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8760,7 +8746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8771,11 +8757,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/6714c94e-8574-436d-a0b1-ccf47db877b5_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004641>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -8791,7 +8794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8807,7 +8810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8828,7 +8831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8841,7 +8844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8855,7 +8858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8871,7 +8874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8885,7 +8888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8901,7 +8904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8918,7 +8921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8937,7 +8940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8956,7 +8959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8975,7 +8978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8994,7 +8997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9005,22 +9008,16 @@
           <http://model.geneontology.org/YeastPathways_DENOVOPURINE2-PWY/YeastPathways_DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -9031,7 +9028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9047,7 +9044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9066,7 +9063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9082,7 +9079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9097,7 +9094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9110,7 +9107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9135,7 +9132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9162,7 +9159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9179,7 +9176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9189,6 +9186,23 @@
 
 <http://identifiers.org/sgd/S000004830>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_134413_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -9202,7 +9216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9215,7 +9229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9229,7 +9243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9248,7 +9262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9256,17 +9270,6 @@
 
 <http://identifiers.org/sgd/S000002862>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aa6e4ae1-dfd2-447e-a1a3-7731e0e852c4_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9276,7 +9279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9295,7 +9298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9310,11 +9313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9322,7 +9325,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/490f3c85-f8e3-4291-a71b-b6bee759f6bc_GART-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9333,7 +9336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9352,7 +9355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9368,7 +9371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9379,7 +9382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9393,7 +9396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9409,7 +9412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9423,7 +9426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9442,7 +9445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9460,7 +9463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9473,7 +9476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9489,7 +9492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9502,7 +9505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9516,7 +9519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9532,7 +9535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9543,7 +9546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9554,7 +9557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9567,7 +9570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9583,7 +9586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9602,7 +9605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9622,7 +9625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9638,7 +9641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9653,7 +9656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9672,7 +9675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9688,7 +9691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9713,7 +9716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9733,7 +9736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9749,7 +9752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9765,7 +9768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9776,7 +9779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9790,7 +9793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9809,7 +9812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9828,7 +9831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9847,7 +9850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_DENOVOPURINE3-PWY.ttl
+++ b/models/YeastPathways_DENOVOPURINE3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12,7 +12,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,11 +214,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004044>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -611,18 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -663,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -674,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -855,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,26 +891,15 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_dd57ce61-136b-499b-96af-13840eee2a88_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,7 +907,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN>
+          <http://model.geneontology.org/dd57ce61-136b-499b-96af-13840eee2a88_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
@@ -941,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -976,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -987,18 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1056,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1069,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1160,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1334,7 +1301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1372,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1442,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1485,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1513,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1630,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1690,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1701,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1715,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1729,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,7 +1715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,7 +1734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1786,7 +1753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1805,7 +1772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1821,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1846,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,11 +1828,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_572e3624-d51e-4d85-bdd2-71fb13eab1b6_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1873,7 +1840,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/572e3624-d51e-4d85-bdd2-71fb13eab1b6_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_BFO_0000066_reaction_AIRCARBOXY-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
@@ -1881,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1892,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1903,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1918,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1931,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1970,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1996,11 +1963,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45578> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2012,7 +1996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2061,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2075,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2100,7 +2084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,7 +2164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,7 +2183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2218,7 +2202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,7 +2221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2275,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2290,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2307,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2323,7 +2307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,7 +2329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,7 +2348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2384,9 +2368,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/CHEBI_134413_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/dd57ce61-136b-499b-96af-13840eee2a88_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2394,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2413,7 +2397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2444,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2455,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2468,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2498,7 +2482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2518,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2565,7 +2549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2581,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2596,7 +2580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2613,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,7 +2613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2649,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2664,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,7 +2664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2699,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2710,7 +2694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2725,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2744,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2763,7 +2747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2782,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2793,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2829,7 +2813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2849,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2862,7 +2846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2871,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2883,7 +2867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2899,7 +2883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2913,7 +2897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2929,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2943,7 +2927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2959,7 +2943,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2977,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2992,7 +2987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3011,7 +3006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3031,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3044,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3057,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3070,7 +3065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3083,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3096,7 +3091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,7 +3135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3153,7 +3148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3168,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3179,12 +3174,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3197,7 +3195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3224,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3240,7 +3238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3259,7 +3257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3288,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3304,7 +3302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3323,7 +3321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3342,7 +3340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3358,7 +3356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3370,7 +3368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3389,7 +3387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3405,7 +3403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3420,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3433,7 +3431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3469,7 +3467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3488,7 +3486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3518,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3537,7 +3535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3548,7 +3546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3562,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3573,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3584,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3601,7 +3599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3617,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3630,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3647,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3664,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3684,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3700,7 +3698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3711,7 +3709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3722,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3739,7 +3737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3758,7 +3756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,7 +3772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3785,7 +3783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3799,7 +3797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3818,7 +3816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3838,7 +3836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3853,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3865,11 +3863,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3877,25 +3875,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_GART-RXN>
 ] .
-
-<http://model.geneontology.org/a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3905,7 +3886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3919,7 +3900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3941,7 +3922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3987,7 +3968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4006,7 +3987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4033,7 +4014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4044,7 +4025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4055,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4066,7 +4047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4077,7 +4058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4088,7 +4069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4102,7 +4083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4118,7 +4099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4132,7 +4113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4146,7 +4127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4162,7 +4143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4171,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4182,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4196,7 +4177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4216,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4232,7 +4213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4252,7 +4233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4268,7 +4249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4293,7 +4274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4304,6 +4285,17 @@
           <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_572e3624-d51e-4d85-bdd2-71fb13eab1b6_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
@@ -4312,7 +4304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4331,7 +4323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4351,7 +4343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4368,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4381,7 +4373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4395,7 +4387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4423,7 +4415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4436,7 +4428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4448,7 +4440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4467,7 +4459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4487,7 +4479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4500,7 +4492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4511,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4526,7 +4518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4544,7 +4536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4557,7 +4549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4568,7 +4560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4588,7 +4580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4608,7 +4600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4621,7 +4613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4632,7 +4624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4643,7 +4635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4654,7 +4646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4665,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4676,7 +4668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4691,7 +4683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4708,7 +4700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4724,7 +4716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4746,7 +4738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4762,7 +4754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4776,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4788,7 +4780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4807,7 +4799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4823,7 +4815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4837,7 +4829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4853,7 +4845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4867,7 +4859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4886,7 +4878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4908,7 +4900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4930,7 +4922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4946,7 +4938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4957,7 +4949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4968,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4985,7 +4977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5001,7 +4993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5016,7 +5008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5029,7 +5021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5043,7 +5035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5060,7 +5052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5080,7 +5072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5097,7 +5089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5114,7 +5106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5141,7 +5133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5154,7 +5146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5165,7 +5157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5179,7 +5171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5212,7 +5204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5227,7 +5219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5240,7 +5232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5255,7 +5247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5271,7 +5263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5290,7 +5282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5310,7 +5302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5326,7 +5318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5346,7 +5338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5362,7 +5354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5381,7 +5373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5397,7 +5389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5412,7 +5404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5428,7 +5420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5444,7 +5436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5455,7 +5447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5467,7 +5459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5478,23 +5470,6 @@
           <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
@@ -5503,7 +5478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5523,7 +5498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5538,7 +5513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5551,7 +5526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5577,7 +5552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5593,7 +5568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5604,7 +5579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5615,7 +5590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5626,7 +5601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5640,7 +5615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5656,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5679,7 +5654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5695,7 +5670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5714,7 +5689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5733,7 +5708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5749,7 +5724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5766,7 +5741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5786,7 +5761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5802,7 +5777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5821,7 +5796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5840,7 +5815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5860,7 +5835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5873,7 +5848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5887,7 +5862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5904,12 +5879,29 @@
 <http://purl.obolibrary.org/obo/GO_0003938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/dd57ce61-136b-499b-96af-13840eee2a88_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5920,7 +5912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5945,7 +5937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5962,7 +5954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5979,7 +5971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5993,12 +5985,23 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6012,7 +6015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6021,7 +6024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6033,7 +6036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6044,6 +6047,17 @@
           <http://model.geneontology.org/reaction_SAICARSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_dd57ce61-136b-499b-96af-13840eee2a88_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000070>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6052,7 +6066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6067,7 +6081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6089,7 +6103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6108,7 +6122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6127,7 +6141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6146,7 +6160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6165,7 +6179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6184,7 +6198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6203,7 +6217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6222,7 +6236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6238,7 +6252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6247,7 +6261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6261,7 +6275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6279,7 +6293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6306,7 +6320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6319,7 +6333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6333,7 +6347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6344,7 +6358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6355,7 +6369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6366,7 +6380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6377,7 +6391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6388,7 +6402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6399,7 +6413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6413,7 +6427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6429,7 +6443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6438,7 +6452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6451,7 +6465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6471,7 +6485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6490,7 +6504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6505,11 +6519,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6517,7 +6531,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_YeastPathways_DENOVOPURINE3-PWY/YeastPathways_DENOVOPURINE3-PWY_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
@@ -6525,7 +6539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6539,7 +6553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6559,7 +6573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6575,7 +6589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6594,7 +6608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6610,7 +6624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6624,7 +6638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6640,7 +6654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6654,7 +6668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6673,7 +6687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6687,7 +6701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6706,7 +6720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6725,7 +6739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6745,7 +6759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6761,7 +6775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6772,7 +6786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6793,7 +6807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6809,7 +6823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6823,7 +6837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6839,7 +6853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6853,7 +6867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6873,7 +6887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6886,7 +6900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6904,7 +6918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6923,7 +6937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6942,7 +6956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6958,7 +6972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6967,7 +6981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6981,7 +6995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6997,7 +7011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7008,7 +7022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7022,7 +7036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7041,7 +7055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7060,7 +7074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7076,7 +7090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7091,7 +7105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7108,7 +7122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7124,7 +7138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7146,7 +7160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7165,7 +7179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7184,7 +7198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7202,7 +7216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7215,7 +7229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7229,7 +7243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7251,7 +7265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7266,7 +7280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7286,7 +7300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7302,7 +7316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7318,7 +7332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7329,7 +7343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7338,7 +7352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7349,7 +7363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7363,7 +7377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7382,7 +7396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7404,7 +7418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7420,7 +7434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7431,7 +7445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7445,7 +7459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7461,7 +7475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7470,7 +7484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7487,7 +7501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7509,7 +7523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7525,7 +7539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7539,7 +7553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7555,7 +7569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7568,7 +7582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7584,7 +7598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7595,6 +7609,23 @@
           <http://model.geneontology.org/MONOMER3O-102_GUANYL-KIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/572e3624-d51e-4d85-bdd2-71fb13eab1b6_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
@@ -7603,7 +7634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7619,7 +7650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7630,7 +7661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7641,7 +7672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7652,7 +7683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7667,7 +7698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7680,7 +7711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7691,7 +7722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7704,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7723,7 +7754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7732,7 +7763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7743,7 +7774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7755,7 +7786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7773,7 +7804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7786,7 +7817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7797,7 +7828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7808,7 +7839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7822,7 +7853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7842,7 +7873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of purine nucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -7858,7 +7889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7878,7 +7909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7894,7 +7925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7924,7 +7955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7940,7 +7971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7962,7 +7993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7978,7 +8009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7987,7 +8018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7999,7 +8030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8018,7 +8049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8040,7 +8071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8059,7 +8090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8079,7 +8110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8100,7 +8131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8113,7 +8144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8124,7 +8155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8139,7 +8170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8154,7 +8185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8167,7 +8198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8178,7 +8209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8193,7 +8224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8209,7 +8240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8229,7 +8260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8242,7 +8273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8251,7 +8282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8265,7 +8296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8284,7 +8315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8300,7 +8331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8312,7 +8343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8331,7 +8362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8351,7 +8382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8368,7 +8399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8385,7 +8416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8401,7 +8432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8420,7 +8451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8440,7 +8471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8456,7 +8487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8475,7 +8506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8494,7 +8525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8514,7 +8545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8530,7 +8561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8550,7 +8581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8566,7 +8597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8581,7 +8612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8594,7 +8625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8612,7 +8643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8632,9 +8663,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a647f8a7-3220-4e56-9034-6443c683dc6e_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/572e3624-d51e-4d85-bdd2-71fb13eab1b6_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -8642,7 +8673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8655,7 +8686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8678,7 +8709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8691,7 +8722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8716,24 +8747,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYBiochemicalReaction45664> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8743,7 +8763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8754,29 +8774,23 @@
           <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/0c0e0b2c-31c0-46ea-805c-cbb02d0b2e56_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002413_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8791,7 +8805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8810,7 +8824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8826,7 +8840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8843,7 +8857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8862,7 +8876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8881,7 +8895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8900,7 +8914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8919,7 +8933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8935,7 +8949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8949,7 +8963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8968,7 +8982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8988,7 +9002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9003,7 +9017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9019,7 +9033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9035,7 +9049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9046,7 +9060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9057,7 +9071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9068,7 +9082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9083,7 +9097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9096,7 +9110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9121,7 +9135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9137,7 +9151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9148,7 +9162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9162,7 +9176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9176,7 +9190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9199,7 +9213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -9215,7 +9229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9230,7 +9244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9246,7 +9260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9265,7 +9279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9287,7 +9301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9303,7 +9317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9317,7 +9331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9336,7 +9350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9352,7 +9366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9366,7 +9380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9385,7 +9399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9405,7 +9419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9421,7 +9435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9440,7 +9454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9456,7 +9470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9467,7 +9481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9478,7 +9492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9493,7 +9507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9506,7 +9520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9517,7 +9531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9528,7 +9542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9542,7 +9556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9572,7 +9586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9585,7 +9599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9610,7 +9624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9627,7 +9641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9637,6 +9651,23 @@
 
 <http://identifiers.org/sgd/S000004830>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_134413_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -9650,7 +9681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9663,7 +9694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9674,18 +9705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9699,7 +9719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9721,7 +9741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9732,7 +9752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9746,7 +9766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9765,7 +9785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9780,11 +9800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9792,7 +9812,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c2fbfcb2-28e0-4f85-9a77-d4053f83caed_GART-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002233_CHEBI_15378_RXN0-745_SGD_PWY_YeastPathways_DENOVOPURINE3-PWY>
@@ -9800,7 +9820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9811,7 +9831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9825,7 +9845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9844,7 +9864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9863,7 +9883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9882,7 +9902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9901,7 +9921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9919,7 +9939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9932,7 +9952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9948,7 +9968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9961,7 +9981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9972,7 +9992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9986,7 +10006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10005,7 +10025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10021,7 +10041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10034,7 +10054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10047,7 +10067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10061,7 +10081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10080,7 +10100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10096,7 +10116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10111,7 +10131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10127,7 +10147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10142,7 +10162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10161,7 +10181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10191,7 +10211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10211,7 +10231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10227,7 +10247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10243,7 +10263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10257,7 +10277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10268,23 +10288,6 @@
           <http://model.geneontology.org/CHEBI_57667_ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/938e1ee6-3674-4173-821f-fd45075cf301_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
@@ -10293,7 +10296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10309,7 +10312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10320,7 +10323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10334,7 +10337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10353,7 +10356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_DETOX1-PWY.ttl
+++ b/models/YeastPathways_DETOX1-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -16,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,19 +349,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_CATAL-RXN_BFO_0000066_reaction_CATAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_DETOX1-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_18421_SUPEROX-DISMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18421> ;
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superoxide radicals degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_ERGOSTEROL-SYN-PWY-1.ttl
+++ b/models/YeastPathways_ERGOSTEROL-SYN-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -101,7 +101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,23 +216,23 @@
           <http://model.geneontology.org/CHEBI_57783_RXN66-319>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002234_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,17 +356,6 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
@@ -375,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -467,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,29 +486,15 @@
           <http://model.geneontology.org/YHR007C-MONOMER_RXN3O-9820_controller>
 ] .
 
-<http://model.geneontology.org/416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +502,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -538,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -580,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -697,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -769,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -830,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,17 +950,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/CHEBI_146130_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/CHEBI_146131_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9826> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1051,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1062,15 +1037,37 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1078,19 +1075,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9826>
 ] .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1100,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1227,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1238,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1249,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1294,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1343,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1376,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1387,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1400,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1444,23 +1430,6 @@
 <http://purl.obolibrary.org/obo/GO_0003838>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57856_RXN3O-178>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1470,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1485,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1501,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1545,7 +1514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1561,7 +1530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,7 +1610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,6 +1624,9 @@
 <http://identifiers.org/sgd/S000004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_143575>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
@@ -1663,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1797,7 +1769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1817,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1858,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1873,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1933,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1956,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1972,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +1958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2002,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2016,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2049,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2060,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2113,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2151,18 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2176,7 +2137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2206,7 +2167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,7 +2186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2253,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2291,7 +2252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2307,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2321,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,7 +2298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2352,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2365,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2374,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2385,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2398,7 +2359,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/CHEBI_143575_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2408,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2428,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2441,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2452,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2463,7 +2424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2478,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2491,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2500,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2514,7 +2475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2533,7 +2494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2558,7 +2519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2577,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2607,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2618,7 +2579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2636,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2652,7 +2613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2688,7 +2649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2710,7 +2671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2725,11 +2686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2737,7 +2698,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_146131_RXN3O-9825>
 ] .
 
 <http://identifiers.org/sgd/S000001114>
@@ -2751,7 +2712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2770,7 +2731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2789,7 +2750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2808,7 +2769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2824,7 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2835,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2849,7 +2810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2865,7 +2826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2874,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2885,7 +2846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2896,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2911,7 +2872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2938,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2951,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2963,7 +2924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2979,7 +2940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2994,7 +2955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3019,7 +2980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3035,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3046,7 +3007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3061,7 +3022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3084,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3111,7 +3072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,7 +3088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3157,7 +3118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3173,7 +3134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3187,7 +3148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,7 +3171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3226,7 +3187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3244,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,7 +3221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3296,7 +3257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3315,7 +3276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3334,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3361,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3376,7 +3337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3393,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3412,7 +3373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3435,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3454,7 +3415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3474,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3494,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3510,7 +3471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3526,18 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3546,7 +3496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3560,7 +3510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3579,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3593,7 +3543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3609,7 +3559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3620,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3634,7 +3584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3675,7 +3625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3691,7 +3641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3707,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3719,7 +3669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3741,7 +3691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3757,7 +3707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3765,11 +3715,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,7 +3727,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3788,7 +3738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3813,7 +3763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3829,7 +3779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3841,7 +3791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3857,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3866,7 +3816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3877,7 +3827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3888,7 +3838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3903,7 +3853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3922,7 +3872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3941,7 +3891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3955,7 +3905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3969,7 +3919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3985,7 +3935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3996,7 +3946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4013,7 +3963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4032,7 +3982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4048,7 +3998,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4065,7 +4026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4080,32 +4041,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9823> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-9823_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004421> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4126,7 +4068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4136,13 +4078,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000066_reaction_RXN3O-9823_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9823> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-9823_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4158,7 +4119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4172,7 +4133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4183,6 +4144,17 @@
           <http://model.geneontology.org/CHEBI_52972_RXN3O-9827>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002413_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
@@ -4191,7 +4163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4210,7 +4182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4229,7 +4201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4245,7 +4217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4260,7 +4232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4279,7 +4251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4297,13 +4269,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58901> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJL167W-MONOMER_FPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003703> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4312,7 +4295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4328,7 +4311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4347,7 +4330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4367,7 +4350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4380,7 +4363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4395,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4412,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4425,7 +4408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4450,7 +4433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4463,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4474,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4485,7 +4468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4499,7 +4482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4510,7 +4493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4525,7 +4508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4541,7 +4524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4560,7 +4543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4576,7 +4559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4590,7 +4573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4601,7 +4584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4613,7 +4596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4632,7 +4615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4662,7 +4645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4678,7 +4661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4697,7 +4680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4719,7 +4702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4738,7 +4721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4752,7 +4735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4768,7 +4751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4782,7 +4765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4801,7 +4784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4820,7 +4803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4840,7 +4823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4856,7 +4839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4872,7 +4855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4883,7 +4866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4906,7 +4889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4923,7 +4906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4938,13 +4921,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58955> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_146131>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
         a       <http://identifiers.org/sgd/S000003292> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4953,7 +4939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4980,7 +4966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4993,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5006,7 +4992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5019,7 +5005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5034,7 +5020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5050,7 +5036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5069,7 +5055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5082,7 +5068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5095,7 +5081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5109,7 +5095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5128,7 +5114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5142,7 +5128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5162,7 +5148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5178,7 +5164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5197,7 +5183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5216,7 +5202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5231,7 +5217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5247,7 +5233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5280,7 +5266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5296,7 +5282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5312,7 +5298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5327,13 +5313,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58832> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002413_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5343,7 +5340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5362,7 +5359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5381,7 +5378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5411,7 +5408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5428,7 +5425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5441,7 +5438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5451,11 +5448,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5463,7 +5460,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_146130_RXN3O-9824>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5474,7 +5471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5494,7 +5491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5507,7 +5504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5518,7 +5515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5529,7 +5526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5543,7 +5540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5559,7 +5556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5574,7 +5571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5587,7 +5584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5607,7 +5604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5627,7 +5624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5646,7 +5643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5665,7 +5662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5681,7 +5678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5696,7 +5693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5709,7 +5706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5723,7 +5720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5742,7 +5739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5753,7 +5750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5764,7 +5761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5779,15 +5776,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN66-314> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
+                <http://model.geneontology.org/CHEBI_146130_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9825> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5803,7 +5800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5822,7 +5819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5841,7 +5838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5856,11 +5853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5868,7 +5865,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_143575_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5879,7 +5876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5898,7 +5895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5917,7 +5914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5937,7 +5934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5953,7 +5950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5967,7 +5964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5983,7 +5980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5998,7 +5995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6011,7 +6008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6022,7 +6019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6033,7 +6030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6048,7 +6045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6061,7 +6058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6073,7 +6070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6091,7 +6088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6104,7 +6101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6117,7 +6114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6136,7 +6133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6155,7 +6152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6180,7 +6177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6193,7 +6190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6207,7 +6204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6227,7 +6224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6243,7 +6240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6254,23 +6251,29 @@
           <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_146130_RXN3O-9824>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_146130> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_57557_PHOSPHOMEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6295,7 +6298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6308,7 +6311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6322,7 +6325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6341,7 +6344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6357,7 +6360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6371,7 +6374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6387,7 +6390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6397,11 +6400,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6409,7 +6412,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9824>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -6423,7 +6426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6439,7 +6442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6450,7 +6453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6467,7 +6470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6483,7 +6486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6497,7 +6500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6516,7 +6519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6532,7 +6535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6547,7 +6550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6560,7 +6563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6571,7 +6574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6586,7 +6589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6599,7 +6602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6613,7 +6616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6626,7 +6629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6642,7 +6645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6662,7 +6665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6673,7 +6676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6687,7 +6690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6705,7 +6708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6722,7 +6725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6739,7 +6742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6756,7 +6759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6769,7 +6772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6780,7 +6783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6794,7 +6797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6812,7 +6815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6828,7 +6831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6844,7 +6847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6855,7 +6858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6866,7 +6869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6877,7 +6880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6888,7 +6891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6902,7 +6905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6921,7 +6924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6941,7 +6944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6957,7 +6960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6976,7 +6979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6987,6 +6990,17 @@
           <http://model.geneontology.org/RXN-12263>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
@@ -6995,7 +7009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7014,7 +7028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7033,7 +7047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7051,7 +7065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7070,7 +7084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7086,7 +7100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7100,7 +7114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7123,7 +7137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7136,7 +7150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7147,7 +7161,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7161,7 +7186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7181,7 +7206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7197,7 +7222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7211,7 +7236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7229,7 +7254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7242,7 +7267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7253,7 +7278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7261,17 +7286,6 @@
 
 <http://identifiers.org/sgd/S000001233>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7281,7 +7295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7297,7 +7311,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7312,24 +7337,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58982> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7339,7 +7353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7350,12 +7364,23 @@
           <http://model.geneontology.org/CHEBI_18252_RXN66-319>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7369,7 +7394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7388,7 +7413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7404,7 +7429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7419,7 +7444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7432,7 +7457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7446,7 +7471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7465,7 +7490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7484,7 +7509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7500,7 +7525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7514,7 +7539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7530,7 +7555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7544,7 +7569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7560,7 +7585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7575,7 +7600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7592,7 +7617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7605,18 +7630,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_143575_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_143575> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7630,7 +7672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7652,7 +7694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7674,7 +7716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7693,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7704,7 +7746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7715,7 +7757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7726,7 +7768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7737,7 +7779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7751,7 +7793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7765,7 +7807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7784,7 +7826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7804,7 +7846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7820,7 +7862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7836,7 +7878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7847,18 +7889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7869,28 +7900,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002234_CHEBI_16526_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7900,7 +7925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7916,7 +7941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7927,7 +7952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7942,9 +7967,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/CHEBI_146131_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_143575_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7952,7 +7977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7968,7 +7993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7984,7 +8009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7998,7 +8023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8017,7 +8042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8035,7 +8060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8051,7 +8076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8070,7 +8095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8086,7 +8111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8101,7 +8126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8117,7 +8142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8133,7 +8158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8147,7 +8172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8163,7 +8188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8177,7 +8202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8197,7 +8222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8214,7 +8239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8222,23 +8247,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002333_YJL167W-MONOMER_GPPSYN-RXN_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8252,7 +8266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8272,7 +8286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8285,18 +8299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_da7fd5aa-4c92-4733-9e59-1484c64553a6_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8314,11 +8317,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58696> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_146131_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_146131> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -8341,7 +8361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8357,7 +8377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8373,7 +8393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8384,7 +8404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8392,9 +8412,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_1949>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_64925_RXN3O-9823>
         a       <http://purl.obolibrary.org/obo/CHEBI_64925> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8405,7 +8422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8418,7 +8435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8432,7 +8449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8448,7 +8465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8462,7 +8479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8481,7 +8498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8494,17 +8511,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+          "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002413_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -8519,7 +8536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8539,13 +8556,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule59115> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
+        a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "C-3 sterol dehydrogenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59137> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN3O-9821>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000254> ;
@@ -8566,39 +8598,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction59026> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
-        a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-3 sterol dehydrogenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59137> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8608,7 +8614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8626,7 +8632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8639,7 +8645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8656,7 +8662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8675,7 +8681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8695,7 +8701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8707,11 +8713,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8719,26 +8725,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
+          <http://model.geneontology.org/CHEBI_146131_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
@@ -8746,7 +8733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8759,7 +8746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8767,12 +8754,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002234_CHEBI_15378_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN66-306_BFO_0000066_reaction_RXN66-306_location_lociGO_0005829_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8787,7 +8793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8814,7 +8820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8827,7 +8833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8836,23 +8842,23 @@
 <http://identifiers.org/sgd/S000002980>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002413_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-313_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8863,7 +8869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8877,7 +8883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8893,7 +8899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8908,7 +8914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8921,7 +8927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8932,7 +8938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8946,7 +8952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8962,7 +8968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8973,7 +8979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8990,7 +8996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9006,7 +9012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9017,7 +9023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9030,7 +9036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9042,11 +9048,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9054,7 +9060,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/416e20df-e661-4cb0-8052-7ae908c232fa_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_143575_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9065,7 +9071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9085,7 +9091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9101,7 +9107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9121,7 +9127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9137,7 +9143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9156,7 +9162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9167,23 +9173,6 @@
           <http://model.geneontology.org/YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/65cc70bc-fd73-4e92-9622-ed63b43c2ae5_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
@@ -9192,7 +9181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9208,7 +9197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9219,7 +9208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9233,7 +9222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9249,7 +9238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9263,7 +9252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9283,7 +9272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9299,7 +9288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9308,6 +9297,53 @@
           <http://model.geneontology.org/RXN3O-9821> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_13392_RXN3O-9821>
+] .
+
+<http://model.geneontology.org/CHEBI_13390_RXN3O-9821>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD(P)<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58886> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_36464_1.1.1.34-RXN>
@@ -9319,60 +9355,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58554> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_13390_RXN3O-9821>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD(P)<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58886> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002233_CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.3.1.71-RXN_RO_0002233_CHEBI_15378_1.3.1.71-RXN_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-319>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102176> ;
@@ -9393,7 +9382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9410,7 +9399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9423,7 +9412,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9437,7 +9437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9448,17 +9448,6 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9826>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000050_YeastPathways_ERGOSTEROL-SYN-PWY-1/YeastPathways_ERGOSTEROL-SYN-PWY-1_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_50586_RXN3O-203>
         a       <http://purl.obolibrary.org/obo/CHEBI_50586> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9468,7 +9457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9481,7 +9470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9495,7 +9484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9515,7 +9504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9531,7 +9520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9561,7 +9550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9569,12 +9558,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002413_RXN-12263_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9588,7 +9588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9604,7 +9604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9615,7 +9615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9626,7 +9626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9637,7 +9637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9648,7 +9648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9659,7 +9659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9675,7 +9675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9694,7 +9694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9713,7 +9713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9733,7 +9733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9745,11 +9745,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9757,7 +9757,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1eb2327c-9441-4117-b261-e6841c206dce_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9768,7 +9768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9788,7 +9788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9804,7 +9804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9823,7 +9823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9839,7 +9839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9854,7 +9854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9871,7 +9871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9887,7 +9887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9903,7 +9903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9921,7 +9921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9937,7 +9937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9956,7 +9956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9967,7 +9967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9978,7 +9978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9992,18 +9992,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_146130>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002233_CHEBI_1949_RXN66-314_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10028,7 +10031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10055,7 +10058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10066,9 +10069,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/531a4b6f-c29b-4d85-a97f-81db11cd50a5_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9821_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -10076,7 +10076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10092,7 +10092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10110,7 +10110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10123,7 +10123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10136,7 +10136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10152,7 +10152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10166,7 +10166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10184,7 +10184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10200,7 +10200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10230,7 +10230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10250,7 +10250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10266,7 +10266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10285,7 +10285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10307,7 +10307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10326,7 +10326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10340,7 +10340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10360,7 +10360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10376,7 +10376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10395,7 +10395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10411,7 +10411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10425,7 +10425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10441,7 +10441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10453,7 +10453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10472,7 +10472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10482,6 +10482,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GPPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004337> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10502,30 +10519,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction58739> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -10536,7 +10536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10549,7 +10549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10560,7 +10560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10571,7 +10571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10582,7 +10582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10597,7 +10597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10613,7 +10613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10632,7 +10632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10643,21 +10643,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/3eea751e-7ad3-46fc-9ae9-7e02d091de67_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_57783_RXN66-319_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10671,7 +10668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10682,7 +10679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10699,7 +10696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10719,7 +10716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10738,7 +10735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10752,7 +10749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10771,7 +10768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10790,7 +10787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10810,7 +10807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10828,7 +10825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10844,7 +10841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10860,7 +10857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10874,7 +10871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10899,7 +10896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10915,7 +10912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10934,7 +10931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10953,7 +10950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10972,7 +10969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10988,7 +10985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11002,7 +10999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11018,7 +11015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11029,7 +11026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11040,7 +11037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11055,7 +11052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11071,7 +11068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11090,7 +11087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11113,7 +11110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11126,7 +11123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11141,7 +11138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11154,7 +11151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11167,7 +11164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11184,7 +11181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11200,7 +11197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11215,7 +11212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11231,7 +11228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11247,7 +11244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11267,7 +11264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11297,7 +11294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11314,7 +11311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11333,7 +11330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11352,7 +11349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11366,7 +11363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11385,7 +11382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11404,7 +11401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11423,7 +11420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11434,7 +11431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11445,7 +11442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11456,7 +11453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11466,11 +11463,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11478,7 +11475,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9824>
+          <http://model.geneontology.org/CHEBI_146130_RXN3O-9824>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1>
@@ -11486,7 +11483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11497,7 +11494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11511,7 +11508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11533,7 +11530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11549,7 +11546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11563,7 +11560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11585,7 +11582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11605,7 +11602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11622,7 +11619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11635,7 +11632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11646,7 +11643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11660,7 +11657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11671,7 +11668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11682,7 +11679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11693,7 +11690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11704,7 +11701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11715,7 +11712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11726,7 +11723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11738,7 +11735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11754,7 +11751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11766,7 +11763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11785,7 +11782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11796,7 +11793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11807,7 +11804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11822,7 +11819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11838,7 +11835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11854,7 +11851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11865,7 +11862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11879,7 +11876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11895,7 +11892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11909,7 +11906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11929,7 +11926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11939,17 +11936,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" , "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002413_RXN3O-9826_SGD_PWY_YeastPathways_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -11965,7 +11962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11981,7 +11978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11999,7 +11996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12018,7 +12015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12034,7 +12031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12048,7 +12045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12068,7 +12065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12084,7 +12081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12103,7 +12100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12119,7 +12116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12133,7 +12130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_FASYN-ELONG2-PWY.ttl
+++ b/models/YeastPathways_FASYN-ELONG2-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -836,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1062,7 +1062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid elongation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1486,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1499,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,7 +1545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1585,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1706,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1720,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1758,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1770,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1821,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1869,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1901,7 +1901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1939,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2045,7 +2045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2127,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2172,7 +2172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2200,7 +2200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2233,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2244,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2255,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2269,7 +2269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2322,7 +2322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2338,7 +2338,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FASYN-ELONG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2351,21 +2362,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FASYN-ELONG2-PWYProtein21257> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9780_RO_0002333_YKL182W-MONOMER_RXN3O-9780_controller_SGD_PWY_YeastPathways_FASYN-ELONG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FASYN-ELONG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_FOLSYN-PWY-1.ttl
+++ b/models/YeastPathways_FOLSYN-PWY-1.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14,19 +14,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003093>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -55,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,7 +63,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +82,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,11 +117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,22 +129,33 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,28 +209,6 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'GTP + H<sub>2</sub>O &rarr; formate + 7,8-dihydroneopterin 3'-triphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -239,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,12 +228,56 @@
           <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15361_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_856e24ea-e1de-4558-90d6-50ddbfcf84f9_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -277,17 +299,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -303,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +349,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,23 +385,12 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -379,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,33 +442,44 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000000042>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -459,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,34 +503,32 @@
           <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
-] .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_20502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -509,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -534,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -549,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -591,11 +622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +634,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
@@ -625,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,11 +690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +702,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
@@ -683,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -763,14 +794,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -780,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,17 +821,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -815,21 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -840,7 +854,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -855,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,12 +899,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_54d6dd1f-8683-4139-a934-da0fd25209d1_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -878,30 +925,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_8c30e8cf-f89f-43e8-be7c-5eec6c65e0f4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,30 +937,27 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/8c30e8cf-f89f-43e8-be7c-5eec6c65e0f4_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -941,11 +966,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +978,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -964,7 +989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -989,18 +1014,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1022,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1034,7 +1059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1075,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_4b6c0fbb-7def-4e90-80ef-dc0212bab8a4_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1063,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1091,7 +1127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,8 +1157,25 @@
           <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0004150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1131,11 +1184,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,10 +1196,10 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004150>
+<http://purl.obolibrary.org/obo/CHEBI_134413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
@@ -1154,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1165,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1181,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1228,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1257,7 +1310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1276,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1287,18 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1323,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,12 +1373,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_43474_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1348,17 +1401,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
@@ -1367,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,12 +1437,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002234_CHEBI_29985_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,17 +1516,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1486,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1515,11 +1557,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_4b6c0fbb-7def-4e90-80ef-dc0212bab8a4_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,54 +1569,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN>
+          <http://model.geneontology.org/4b6c0fbb-7def-4e90-80ef-dc0212bab8a4_1.5.1.15-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1588,7 +1602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,29 +1632,12 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1655,17 +1652,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/8c30e8cf-f89f-43e8-be7c-5eec6c65e0f4_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1688,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1753,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1767,7 +1764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1843,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1862,7 +1859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1878,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,6 +1909,17 @@
           <http://model.geneontology.org/CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1920,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1992,17 +2000,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/856e24ea-e1de-4558-90d6-50ddbfcf84f9_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/THYMIDYLATESYN-RXN> , <http://model.geneontology.org/RXN3O-9789> , <http://model.geneontology.org/1.5.1.15-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN3O-9789> , <http://model.geneontology.org/1.5.1.15-RXN> , <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2010,16 +2018,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2029,7 +2045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2040,31 +2056,12 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN>
-] .
-
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2077,17 +2074,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2107,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,7 +2147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2159,24 +2156,16 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -2187,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2198,22 +2187,24 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2223,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,14 +2225,12 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000000042> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2250,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2265,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2278,7 +2267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2305,11 +2294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2317,7 +2306,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2328,7 +2317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2348,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2371,11 +2360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2383,7 +2372,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2394,7 +2383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2413,7 +2402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2424,12 +2413,12 @@
           <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2439,11 +2428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,29 +2440,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008696>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2494,24 +2483,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction60431> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_63528> ;
@@ -2522,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,7 +2516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2557,7 +2535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2588,24 +2566,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2615,7 +2582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,7 +2601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,9 +2621,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/54d6dd1f-8683-4139-a934-da0fd25209d1_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2664,7 +2631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2676,11 +2643,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2688,7 +2655,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2699,7 +2666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2715,18 +2682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2737,23 +2693,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2763,7 +2708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,15 +2719,26 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2790,7 +2746,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0003934>
@@ -2805,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2818,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2829,7 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2843,7 +2799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2854,12 +2810,23 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2870,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2881,7 +2848,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2895,7 +2873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,7 +2889,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2928,7 +2917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2939,17 +2928,6 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
@@ -2958,7 +2936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2969,6 +2947,17 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17001>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2977,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2991,7 +2980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +2999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3030,7 +3019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3050,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3064,23 +3053,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
@@ -3089,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3108,7 +3080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3127,7 +3099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3157,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3168,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3182,7 +3154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3201,7 +3173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3220,7 +3192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3239,7 +3211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3255,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3266,7 +3238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3290,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3306,7 +3278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,6 +3289,17 @@
           <http://model.geneontology.org/CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
@@ -3325,7 +3308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3339,17 +3322,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000005762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3357,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3373,7 +3345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3388,11 +3360,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_1dd6953a-c5d2-4b11-8052-ea87237639bc_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3372,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789>
+          <http://model.geneontology.org/1dd6953a-c5d2-4b11-8052-ea87237639bc_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
@@ -3408,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3419,42 +3391,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3464,7 +3416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3483,7 +3435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3503,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3516,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3536,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3548,7 +3500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3564,18 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3586,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3600,7 +3541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3611,15 +3552,12 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3632,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3649,7 +3587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3665,7 +3603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3681,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3695,7 +3633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3713,7 +3651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3730,7 +3668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3742,11 +3680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3754,8 +3692,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3766,23 +3715,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3795,11 +3733,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_51fe2270-0660-41e2-9104-74990bc6ba3b_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3807,7 +3745,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/51fe2270-0660-41e2-9104-74990bc6ba3b_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3818,7 +3756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3829,6 +3767,23 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/54d6dd1f-8683-4139-a934-da0fd25209d1_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17071> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3838,7 +3793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3851,7 +3806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3863,7 +3818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3882,7 +3837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3902,17 +3857,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e63cf44d-475c-42b6-b44d-6a6702077227_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3929,7 +3884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3937,26 +3892,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,7 +3908,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002413_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
@@ -3972,7 +3916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3982,11 +3926,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3994,7 +3938,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004489>
@@ -4008,7 +3952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4023,11 +3967,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4035,7 +3979,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
@@ -4047,7 +3991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4061,23 +4005,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_ef4708c7-4d57-4442-b22a-7fda458335e8_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4091,7 +4035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4107,18 +4051,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4131,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4139,42 +4083,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/af70bfa4-5c13-4379-b0ec-b2c99b0b9cc1_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000066_reaction_1.5.1.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4185,7 +4121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4199,7 +4135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4210,8 +4146,25 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_58762>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/856e24ea-e1de-4558-90d6-50ddbfcf84f9_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -4222,7 +4175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4238,7 +4191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4258,7 +4211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4277,7 +4230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4297,7 +4250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4310,7 +4263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4323,30 +4276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVMULTI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4357,19 +4291,57 @@
           <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57305_GCVMULTI-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVMULTI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000000467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002411_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_af70bfa4-5c13-4379-b0ec-b2c99b0b9cc1_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
         a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4378,7 +4350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4386,28 +4358,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000000467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4417,7 +4369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4436,7 +4388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4450,12 +4402,23 @@
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_8c30e8cf-f89f-43e8-be7c-5eec6c65e0f4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4468,7 +4431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of tetrahydrofolate biosynthesis and salvage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4485,9 +4448,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/3d2808a2-08b9-4969-b371-d65d0a89aafc_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/4b6c0fbb-7def-4e90-80ef-dc0212bab8a4_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4495,7 +4458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4514,7 +4477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4525,17 +4488,6 @@
           <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
@@ -4544,7 +4496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4555,23 +4507,23 @@
           <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_17836_ADCLY-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4582,7 +4534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4591,7 +4543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4599,11 +4551,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e63cf44d-475c-42b6-b44d-6a6702077227_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4611,7 +4563,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/e63cf44d-475c-42b6-b44d-6a6702077227_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4622,7 +4574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4652,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4672,7 +4624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4685,7 +4637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4699,7 +4651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4714,11 +4666,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_54d6dd1f-8683-4139-a934-da0fd25209d1_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4726,11 +4678,14 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/efdb1e9e-4a74-421f-8790-e8362eeeeda7_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/54d6dd1f-8683-4139-a934-da0fd25209d1_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004719>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4740,7 +4695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4756,7 +4711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4769,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4786,13 +4741,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60460> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000001788>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17001> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4803,22 +4770,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60395> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4829,7 +4787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4837,18 +4795,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000001788>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e63cf44d-475c-42b6-b44d-6a6702077227_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4863,15 +4854,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/4b2dd6eb-c348-4609-ae78-88f3f2ef9958_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/1dd6953a-c5d2-4b11-8052-ea87237639bc_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4887,7 +4878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4903,7 +4894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4913,11 +4904,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4925,18 +4916,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4944,7 +4935,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
@@ -4952,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4960,53 +4951,33 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD(P)H + H<SUP>+</SUP> &rarr; a 5-methyltetrahydrofolate + NAD(P)<sup>+</sup>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-9789>
 ] .
 
-<http://model.geneontology.org/aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -5017,7 +4988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5030,7 +5001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5044,7 +5015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5063,7 +5034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5077,11 +5048,19 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/1776eea8-97af-49ae-98bb-eea567ad1b25_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5091,7 +5070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5110,7 +5089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5118,6 +5097,23 @@
 
 <http://identifiers.org/sgd/S000005944>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/1dd6953a-c5d2-4b11-8052-ea87237639bc_RXN3O-9789>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_37565>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5127,7 +5123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5142,7 +5138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5159,7 +5155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5175,7 +5171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5186,17 +5182,6 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
@@ -5205,7 +5190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5221,18 +5206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f98d555b-3e4b-4c8e-ad68-e63e1b6f0a13_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5243,7 +5217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5258,7 +5232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5274,7 +5248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5293,7 +5267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5307,23 +5281,12 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5338,7 +5301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5351,7 +5314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5365,7 +5328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5376,29 +5339,23 @@
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
-<http://model.geneontology.org/491cb219-ea5d-416b-b431-71d4450af4a5_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5409,7 +5366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5423,7 +5380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5438,11 +5395,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5450,26 +5407,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5478,17 +5424,6 @@
 <http://purl.obolibrary.org/obo/GO_0019177>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_59bf992c-078c-439b-a224-ed559c39e8f9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005316> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5496,7 +5431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5509,7 +5444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5523,7 +5458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5534,15 +5469,12 @@
           <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5553,7 +5485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5564,13 +5496,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59816> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5580,7 +5523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5591,26 +5534,15 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_30616_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5618,7 +5550,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/221ee795-ae83-42fe-a1ba-2adea78dec40_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
@@ -5630,7 +5562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5643,7 +5575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5652,7 +5584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5666,7 +5598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5681,11 +5613,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_856e24ea-e1de-4558-90d6-50ddbfcf84f9_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5693,7 +5625,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/97afffad-9d24-4bd3-a96c-b05cacb31aff_1.5.1.15-RXN>
+          <http://model.geneontology.org/856e24ea-e1de-4558-90d6-50ddbfcf84f9_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -5703,7 +5635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5730,7 +5662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5743,7 +5675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5757,7 +5689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5776,7 +5708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5792,7 +5724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5803,7 +5735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5817,7 +5749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5837,7 +5769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5850,7 +5782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5861,7 +5793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5875,7 +5807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5894,7 +5826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5913,7 +5845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5932,7 +5864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5943,17 +5875,6 @@
           <http://model.geneontology.org/CHEBI_73083_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5963,7 +5884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5971,12 +5892,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000066_reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5991,7 +5923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6004,7 +5936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6018,7 +5950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6034,7 +5966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6051,7 +5983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6071,7 +6003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6088,7 +6020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6105,7 +6037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6121,7 +6053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6137,7 +6069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6148,7 +6080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6163,7 +6095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6183,17 +6115,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/af70bfa4-5c13-4379-b0ec-b2c99b0b9cc1_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/aae9d28f-7ecf-4636-a8d3-822e4228b3b8_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6205,11 +6137,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6217,7 +6149,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
@@ -6227,26 +6159,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59867> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GTP-cyclohydrolase I" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein60467> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -6255,18 +6172,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GTP-cyclohydrolase I" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein60467> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6280,7 +6212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6298,11 +6230,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6310,7 +6242,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7065e207-6a9a-4413-8e46-d2716a2bc5cb_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
@@ -6318,7 +6250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6330,12 +6262,26 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/e63cf44d-475c-42b6-b44d-6a6702077227_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6345,11 +6291,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6357,7 +6303,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
@@ -6369,9 +6315,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/c4a18306-80f9-453b-a3ce-8d7ebc00438d_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/51fe2270-0660-41e2-9104-74990bc6ba3b_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -6379,7 +6325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6389,33 +6335,22 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58406_PABASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58406> ;
@@ -6426,7 +6361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6443,7 +6378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6451,15 +6386,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000004902>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_51fe2270-0660-41e2-9104-74990bc6ba3b_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6470,7 +6416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6484,7 +6430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6503,7 +6449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6519,7 +6465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6530,7 +6476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6545,7 +6491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6561,7 +6507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6572,7 +6518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6586,7 +6532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6605,7 +6551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6633,7 +6579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6646,7 +6592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6655,12 +6601,15 @@
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6672,7 +6621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6691,7 +6640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6702,15 +6651,23 @@
           <http://model.geneontology.org/CHEBI_58462_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58359>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6719,7 +6676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6730,17 +6687,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" , "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -6754,7 +6711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6769,7 +6726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6786,7 +6743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6803,7 +6760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6816,11 +6773,11 @@
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6836,7 +6793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6852,7 +6809,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_1dd6953a-c5d2-4b11-8052-ea87237639bc_RXN3O-9789_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6866,7 +6834,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6877,18 +6856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6900,11 +6868,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004799>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6915,11 +6886,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60143> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/51fe2270-0660-41e2-9104-74990bc6ba3b_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6928,14 +6916,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004799>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/4b6c0fbb-7def-4e90-80ef-dc0212bab8a4_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -6946,7 +6948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6962,7 +6964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6981,7 +6983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7003,7 +7005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7018,11 +7020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7030,7 +7032,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
@@ -7052,7 +7054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7069,7 +7071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7085,7 +7087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7104,7 +7106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7115,29 +7117,12 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/d24d3c1a-6946-4abc-af85-0badb5e65b66_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7151,7 +7136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7167,7 +7152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7182,7 +7167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7199,7 +7184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7214,11 +7199,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_af70bfa4-5c13-4379-b0ec-b2c99b0b9cc1_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7226,7 +7211,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5772f0df-4884-4529-ba7b-be7ed151deb9_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/af70bfa4-5c13-4379-b0ec-b2c99b0b9cc1_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7237,7 +7222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7253,7 +7238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7264,7 +7249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7278,7 +7263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7297,7 +7282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7316,7 +7301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7336,28 +7321,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60250> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ad112016-44eb-44fa-ae01-9409044476fe_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7369,14 +7337,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/6db40862-b841-40f3-b224-6767737c0932_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7386,7 +7354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7406,7 +7374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7414,8 +7382,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein60272> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7426,11 +7406,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59789> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7442,7 +7439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7453,27 +7450,12 @@
           <http://model.geneontology.org/CHEBI_17836_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein60272> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7488,7 +7470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7501,7 +7483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7514,13 +7496,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59810> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/8c30e8cf-f89f-43e8-be7c-5eec6c65e0f4_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7530,7 +7515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7549,7 +7534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7560,6 +7545,23 @@
           <http://model.geneontology.org/YeastPathways_FOLSYN-PWY-1/YeastPathways_FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -7568,7 +7570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7580,7 +7582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7600,21 +7602,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60007> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_054c3b0b-0214-4a55-b5ae-d35b60071dc1_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_GLNSYN-PWY.ttl
+++ b/models/YeastPathways_GLNSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,7 +133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_GLUCFERMEN-PWY.ttl
+++ b/models/YeastPathways_GLUCFERMEN-PWY.ttl
@@ -1,19 +1,17 @@
-<http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58289> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-phospho-D-glycerate" ;
+                "triosephosphate isomerase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37243> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37372> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -23,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -352,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -648,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -986,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1171,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1218,7 +1216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1309,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1372,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1384,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1414,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1480,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1511,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1577,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1672,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1683,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1696,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1715,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1726,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1740,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1776,7 +1774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,17 +1785,6 @@
           <http://model.geneontology.org/reaction_ALCOHOL-DEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_ALDEHYDE-DEHYDROGENASE-NADP+-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1807,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1820,7 +1807,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002413_RXN-6161_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,7 +1920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1956,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glucose fermentation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1980,7 +1978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2005,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2035,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2052,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2074,7 +2072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2097,7 +2095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2130,7 +2128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2185,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2197,7 +2195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2235,7 +2233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2276,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2293,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2309,7 +2307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,7 +2323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2334,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2345,7 +2343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2356,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2370,7 +2368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2417,23 +2415,6 @@
 <http://identifiers.org/sgd/S000003222>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36910> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
@@ -2442,7 +2423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2453,6 +2434,23 @@
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
+<http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36910> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '3-phospho-D-glycerate + ATP &harr; 3-phospho-D-glyceroyl-phosphate + ADP' 'null' '2-phospho-D-glycerate &harr; 3-phospho-D-glycerate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
@@ -2461,7 +2459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2484,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2501,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2517,7 +2515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2533,7 +2531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2547,7 +2545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2563,7 +2561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2591,7 +2589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2610,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2643,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2660,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2674,7 +2672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2701,7 +2699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2712,7 +2710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2726,7 +2724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2756,7 +2754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,7 +2772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2787,7 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2799,7 +2797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2818,7 +2816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2854,7 +2852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2870,7 +2868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2884,7 +2882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2897,6 +2895,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/6PFRUCTPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003872> ;
@@ -2917,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2925,23 +2934,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002233_CHEBI_456216_PHOSGLYPHOS-RXN_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000066_reaction_3PGAREARR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2952,7 +2950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2964,7 +2962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,7 +2997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3010,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3021,7 +3019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3043,7 +3041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3054,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3068,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3087,7 +3085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3107,7 +3105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3120,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3131,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3146,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3159,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3173,7 +3171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3187,7 +3185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3206,7 +3204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,7 +3220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3247,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,7 +3258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3274,7 +3272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3292,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3308,7 +3306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3324,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3335,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3346,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3361,7 +3359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3399,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3415,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3426,7 +3424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3460,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3473,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3484,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3498,7 +3496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3522,7 +3520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3539,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3555,7 +3553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3574,7 +3572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3604,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3622,7 +3620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3638,7 +3636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3654,7 +3652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3667,7 +3665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3686,7 +3684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,7 +3703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,7 +3719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3734,7 +3732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3763,7 +3761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3779,7 +3777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3798,7 +3796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3814,7 +3812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3828,7 +3826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3842,7 +3840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3858,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3874,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3890,7 +3888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3908,7 +3906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3924,7 +3922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3944,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3961,7 +3959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3977,7 +3975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4002,7 +4000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4024,7 +4022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4040,7 +4038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4056,7 +4054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4072,7 +4070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4086,7 +4084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4106,7 +4104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4119,7 +4117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4132,7 +4130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4149,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4167,7 +4165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4187,7 +4185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4203,7 +4201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4219,7 +4217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4230,7 +4228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4241,7 +4239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4256,7 +4254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4272,7 +4270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4291,7 +4289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4302,7 +4300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4314,7 +4312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4333,7 +4331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4349,7 +4347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4360,7 +4358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4371,7 +4369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4385,7 +4383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4404,7 +4402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4420,7 +4418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4437,7 +4435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4448,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4459,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4474,7 +4472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4490,7 +4488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4509,7 +4507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4528,7 +4526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4542,7 +4540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4561,7 +4559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4577,7 +4575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4588,7 +4586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4604,7 +4602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4620,7 +4618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4639,7 +4637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4655,7 +4653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4669,7 +4667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4688,7 +4686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4697,7 +4695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4723,7 +4721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4739,7 +4737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4755,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4768,7 +4766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4783,7 +4781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4796,7 +4794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4811,7 +4809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4827,7 +4825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4849,7 +4847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4865,7 +4863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4880,7 +4878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4905,7 +4903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4921,7 +4919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4940,7 +4938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4959,7 +4957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4976,7 +4974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5001,7 +4999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5017,7 +5015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5031,7 +5029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5047,7 +5045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5070,7 +5068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5083,7 +5081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5094,7 +5092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5105,7 +5103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5117,7 +5115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5136,7 +5134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5155,7 +5153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5164,7 +5162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5177,7 +5175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5190,7 +5188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5201,7 +5199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5213,7 +5211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5232,7 +5230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5251,7 +5249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5267,7 +5265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5281,7 +5279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5301,7 +5299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5318,7 +5316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5335,7 +5333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5351,7 +5349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5370,7 +5368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5398,7 +5396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5414,7 +5412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5430,7 +5428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5444,7 +5442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5460,7 +5458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5471,7 +5469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5485,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5496,7 +5494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5511,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5524,7 +5522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5537,7 +5535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5553,7 +5551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5583,7 +5581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5599,7 +5597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5615,7 +5613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5626,7 +5624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5640,7 +5638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5656,7 +5654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5667,7 +5665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5682,7 +5680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5698,7 +5696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5717,7 +5715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5733,7 +5731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5748,7 +5746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5761,7 +5759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5778,7 +5776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5797,7 +5795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5813,7 +5811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5828,7 +5826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5844,7 +5842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5864,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5877,7 +5875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5897,7 +5895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,7 +5913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5928,7 +5926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5937,7 +5935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5951,7 +5949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5972,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5989,7 +5987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6005,7 +6003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6027,7 +6025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6043,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6054,7 +6052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6065,7 +6063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6082,7 +6080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6101,7 +6099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6121,7 +6119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6134,7 +6132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6154,7 +6152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6167,7 +6165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6180,7 +6178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6194,7 +6192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6213,7 +6211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6229,7 +6227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6246,7 +6244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6262,7 +6260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6271,7 +6269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6282,7 +6280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6296,7 +6294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6312,7 +6310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6326,7 +6324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6342,7 +6340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6359,7 +6357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6378,7 +6376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6394,7 +6392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6409,7 +6407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6426,7 +6424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6439,7 +6437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6454,7 +6452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6470,7 +6468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6489,7 +6487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6500,7 +6498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6515,7 +6513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6534,7 +6532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6545,22 +6543,16 @@
           <http://model.geneontology.org/GAPOXNPHOSPHN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
+<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37296> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6571,7 +6563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6579,16 +6571,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_BFO_0000066_reaction_2PGADEHYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_43474_GAPOXNPHOSPHN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCFERMEN-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37296> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6598,7 +6596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6612,7 +6610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6623,7 +6621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6637,7 +6635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6656,7 +6654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6676,7 +6674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6692,7 +6690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6706,7 +6704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6725,7 +6723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6741,7 +6739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6759,7 +6757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6777,7 +6775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6793,7 +6791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6812,7 +6810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6831,7 +6829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6848,7 +6846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6870,7 +6868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6889,7 +6887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6907,7 +6905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6924,7 +6922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6939,7 +6937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6955,7 +6953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6973,7 +6971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6989,7 +6987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7008,7 +7006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7033,7 +7031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7055,7 +7053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7071,7 +7069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7080,7 +7078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7094,7 +7092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7113,7 +7111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7132,7 +7130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7155,7 +7153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7171,7 +7169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7187,7 +7185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7198,7 +7196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7209,7 +7207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7234,7 +7232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7242,17 +7240,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/YDR050C-MONOMER_TRIOSEPISOMERIZATION-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_58289_3PGAREARR-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58289> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "triosephosphate isomerase" ;
+                "2-phospho-D-glycerate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37372> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37243> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_GLUCONEO-PWY-1.ttl
+++ b/models/YeastPathways_GLUCONEO-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,7 +979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1485,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1527,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1819,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1835,7 +1835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1851,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1862,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1927,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1943,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2015,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2043,7 +2043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2081,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2097,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2167,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2233,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2244,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2258,7 +2258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2278,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "gluconeogenesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2295,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2308,7 +2308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2331,7 +2331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2346,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2362,7 +2362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2381,7 +2381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2416,7 +2416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2432,7 +2432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2452,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2465,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2479,7 +2479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2516,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2532,7 +2532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2559,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2588,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2618,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2632,7 +2632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,7 +2652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2671,7 +2671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2687,7 +2687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2701,7 +2701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2721,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2745,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2756,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2787,7 +2787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2803,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2817,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2831,7 +2831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2847,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2861,7 +2861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2891,7 +2891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2921,7 +2921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,7 +2940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,7 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3006,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3022,7 +3022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3052,7 +3052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3077,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3094,7 +3094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3113,7 +3113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3132,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3147,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3164,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3180,7 +3180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,7 +3205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3221,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3237,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3253,7 +3253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3278,7 +3278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3290,7 +3290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3312,7 +3312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3331,7 +3331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3347,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3362,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3378,7 +3378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3394,7 +3394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3408,7 +3408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3430,7 +3430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3449,7 +3449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3479,7 +3479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3498,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3512,7 +3512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3532,7 +3532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3545,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3556,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3567,7 +3567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3581,7 +3581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3597,7 +3597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3612,7 +3612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3625,7 +3625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3642,7 +3642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3658,7 +3658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3669,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3680,7 +3680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3691,7 +3691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3705,7 +3705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3726,7 +3726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3739,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3766,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3779,7 +3779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3790,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3804,7 +3804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3818,7 +3818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3843,7 +3843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3859,7 +3859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3876,7 +3876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3926,7 +3926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3942,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3959,7 +3959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3975,7 +3975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3986,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4003,7 +4003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4019,7 +4019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4030,7 +4030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4044,7 +4044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4064,7 +4064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4081,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4097,7 +4097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4119,7 +4119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4139,7 +4139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4152,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4166,7 +4166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4180,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4197,7 +4197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4219,7 +4219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4244,7 +4244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4264,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4284,7 +4284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4300,7 +4300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4316,7 +4316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4331,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4347,7 +4347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4363,7 +4363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4377,7 +4377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4393,7 +4393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4407,7 +4407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4427,7 +4427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4443,7 +4443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4465,7 +4465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4481,7 +4481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4493,7 +4493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4509,7 +4509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4520,7 +4520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4531,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4556,7 +4556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
+++ b/models/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14,22 +14,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-413>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol' 'null' 'GDP-&alpha;-D-mannose + Man(3)GlcNAc(2)-PP-Dol &rarr; GDP + Man(4)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002411_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002413_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -68,16 +68,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -87,7 +84,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,11 +95,33 @@
           <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002413_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000003033>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_53742_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -112,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,12 +161,29 @@
           <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_28067_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28067> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(2)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002333_MONOMER3O-36_RXN3O-379_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -157,11 +193,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +205,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259>
+          <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -184,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,11 +232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_53023_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,54 +244,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291>
+          <http://model.geneontology.org/CHEBI_53023_RXN3O-291>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002411_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002411_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_38f2d8e3-b789-4775-8db0-114c15732fbc_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +266,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN>
+          <http://model.geneontology.org/38f2d8e3-b789-4775-8db0-114c15732fbc_2.4.1.132-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -274,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -308,20 +311,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_145644_RXN3O-412>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_145644> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(8)GlcNAc(2)-PP-Dol" ;
+                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -334,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,17 +347,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'a dolichyl &beta;-D-glucosyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(3)Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002411_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002413_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -367,12 +370,34 @@
 <http://purl.obolibrary.org/obo/GO_0004577>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002413_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000066_reaction_RXN3O-413_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_145630_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -425,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -436,18 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -552,11 +566,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_7bdeeb17-bb1c-483f-b64c-eb894649d8a9_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,39 +578,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379>
+          <http://model.geneontology.org/7bdeeb17-bb1c-483f-b64c-eb894649d8a9_RXN3O-379>
 ] .
-
-<http://model.geneontology.org/f259a394-e6b4-4366-98d0-511206579371_RXN3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(7)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002411_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002413_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -611,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,28 +624,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-413>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
@@ -659,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,32 +678,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_28067>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -738,23 +718,37 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/f2ec75a1-06cc-40a3-944b-ca001e92b131_RXN3O-379> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/CHEBI_53022_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-291> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLBiochemicalReaction28203> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_37637_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_53742>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -764,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,16 +795,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28101> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://identifiers.org/sgd/S000000314>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -824,17 +815,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291> , <http://model.geneontology.org/fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3> ;
+                <http://model.geneontology.org/CHEBI_15809_RXN3O-3> , <http://model.geneontology.org/CHEBI_53023_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f259a394-e6b4-4366-98d0-511206579371_RXN3O-3> , <http://model.geneontology.org/CHEBI_16214_RXN3O-3> ;
+                <http://model.geneontology.org/CHEBI_59088_RXN3O-3> , <http://model.geneontology.org/CHEBI_16214_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-11> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,19 +838,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_145644>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_145597_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +861,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57525_RXN3O-412>
+          <http://model.geneontology.org/CHEBI_145597_RXN3O-411>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -878,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,8 +913,30 @@
           <http://model.geneontology.org/CHEBI_16214_RXN3O-3>
 ] .
 
-<http://model.geneontology.org/7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/CHEBI_59091>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_7bdeeb17-bb1c-483f-b64c-eb894649d8a9_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_CHEBI_53023_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16214_2.7.8.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -931,41 +947,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(1)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -975,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,14 +982,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1011,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,12 +1007,23 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_CHEBI_53022_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1035,11 +1031,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_CHEBI_15809_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,15 +1043,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259>
+          <http://model.geneontology.org/CHEBI_15809_RXN3O-259>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_CHEBI_53023_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1066,13 +1073,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28176> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_CHEBI_15809_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1082,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,11 +1115,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_f2ec75a1-06cc-40a3-944b-ca001e92b131_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1127,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379>
+          <http://model.geneontology.org/f2ec75a1-06cc-40a3-944b-ca001e92b131_RXN3O-379>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1123,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1133,11 +1151,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_145597_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1145,7 +1163,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
+          <http://model.geneontology.org/CHEBI_145597_RXN3O-411>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0006488>
@@ -1160,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1176,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1219,17 +1237,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11> , <http://model.geneontology.org/7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3> ;
+                <http://model.geneontology.org/CHEBI_15809_RXN3O-11> , <http://model.geneontology.org/CHEBI_59088_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-11> , <http://model.geneontology.org/df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-11> , <http://model.geneontology.org/CHEBI_59091_RXN3O-11> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-259> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,15 +1255,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_145597_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_145597_RXN3O-411>
+        a       <http://purl.obolibrary.org/obo/CHEBI_145597> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1254,25 +1300,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
-] .
-
 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003459> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1280,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,11 +1319,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-24_2.4.1.141-RXN_controller_BFO_0000051_SGD_S000003015_CPLX3O-24_component_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,18 +1372,46 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
+<http://model.geneontology.org/CHEBI_59091_RXN3O-11>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59091> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(8)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004578>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_59091_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_28067_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,25 +1419,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
+          <http://model.geneontology.org/CHEBI_28067_2.4.1.132-RXN>
 ] .
-
-<http://model.geneontology.org/fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000447>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1377,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1393,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1403,11 +1460,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_61895_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1472,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818>
+          <http://model.geneontology.org/CHEBI_61895_RXN3O-9818>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1423,17 +1480,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002411_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1443,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,17 +1525,6 @@
           <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58223> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1499,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1527,17 +1562,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
+                <http://model.geneontology.org/CHEBI_28067_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_RXN3O-378> , <http://model.geneontology.org/f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378> ;
+                <http://model.geneontology.org/CHEBI_53742_RXN3O-378> , <http://model.geneontology.org/CHEBI_58189_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-379> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1550,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,7 +1637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1648,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1668,29 +1703,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(4)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1702,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1728,29 +1746,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1762,7 +1763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,11 +1797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_57525_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,18 +1809,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411>
+          <http://model.geneontology.org/CHEBI_57525_RXN3O-412>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_59091_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1827,7 +1828,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11>
+          <http://model.geneontology.org/CHEBI_59091_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
@@ -1835,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1843,11 +1844,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_f259a394-e6b4-4366-98d0-511206579371_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_59088_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1855,25 +1856,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f259a394-e6b4-4366-98d0-511206579371_RXN3O-3>
+          <http://model.geneontology.org/CHEBI_59088_RXN3O-3>
 ] .
-
-<http://model.geneontology.org/f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(6)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_12427> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1884,24 +1868,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27951> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002411_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1911,7 +1884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,12 +1895,34 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_145644_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_38f2d8e3-b789-4775-8db0-114c15732fbc_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1967,11 +1962,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_CHEBI_59091_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1974,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11>
+          <http://model.geneontology.org/CHEBI_59091_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/RXN3O-9818>
@@ -1993,15 +1988,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN> , <http://model.geneontology.org/CHEBI_57527_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818> , <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> ;
+                <http://model.geneontology.org/CHEBI_61895_RXN3O-9818> , <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/2.4.1.132-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,6 +2007,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002413_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
@@ -2020,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,11 +2041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_53022_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2053,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN>
+          <http://model.geneontology.org/CHEBI_53022_2.4.1.131-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
@@ -2058,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2068,11 +2074,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_CHEBI_16214_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2080,7 +2086,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002333_YNL219C-MONOMER_RXN3O-3_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2088,21 +2094,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_f259a394-e6b4-4366-98d0-511206579371_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002413_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2121,17 +2124,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(5)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(6)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002411_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002413_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2146,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,17 +2168,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(1)GlcNAc(2)-PP-Dol &rarr; a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide + Man(2)GlcNAc(2)-PP-Dol + GDP' 'null' 'GDP-&alpha;-D-mannose + Man(2)GlcNAc(2)-PP-Dol &rarr; GDP + Man(3)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002411_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002413_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2190,7 +2193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,24 +2211,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28176> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
         a       <http://identifiers.org/sgd/S000005313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2234,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2247,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2259,7 +2251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,40 +2262,29 @@
           <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/CHEBI_37637_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37637> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002333_YBL082C-MONOMER_RXN3O-291_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(3)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2313,11 +2294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,38 +2306,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN>
+          <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_145597>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(5)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002413_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2365,11 +2340,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0042281>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/2.4.1.141-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004577> ;
@@ -2390,16 +2368,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLBiochemicalReaction28000> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/GO_0042281>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000314> ;
@@ -2408,13 +2383,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein27997> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002413_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57527> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2425,61 +2411,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2492,9 +2428,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-379> ;
+                <http://model.geneontology.org/CHEBI_53742_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_RXN3O-379> , <http://model.geneontology.org/1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379> ;
+                <http://model.geneontology.org/CHEBI_58189_RXN3O-379> , <http://model.geneontology.org/7bdeeb17-bb1c-483f-b64c-eb894649d8a9_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2502,13 +2438,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLBiochemicalReaction28179> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_CHEBI_15809_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2518,7 +2465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2529,19 +2476,36 @@
           <http://model.geneontology.org/CHEBI_15378_2.4.1.141-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_59088_RXN3O-3>
+        a       <http://purl.obolibrary.org/obo/CHEBI_59088> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(7)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation '<i>N</i>-acetyl-&beta;-D-glucosaminyl-(1&rarr;4)-<i>N</i>-acetyl-&alpha;-D-glucosaminyl-diphosphodolichol + GDP-&alpha;-D-mannose &rarr; Man(1)GlcNAc(2)-PP-Dol + GDP' 'null' 'GDP-&alpha;-D-mannose + Man(1)GlcNAc(2)-PP-Dol &rarr; a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide + Man(2)GlcNAc(2)-PP-Dol + GDP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002411_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002413_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2556,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2570,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2585,11 +2549,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_CHEBI_15809_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2597,29 +2561,48 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291>
+          <http://model.geneontology.org/CHEBI_15809_RXN3O-291>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_28067_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_CHEBI_59091_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002333_YGL065C-MONOMER_2.4.1.132-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2630,21 +2613,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/CHEBI_15809_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15809> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_61895_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,7 +2652,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818>
+          <http://model.geneontology.org/CHEBI_61895_RXN3O-9818>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2660,7 +2660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2673,11 +2673,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_145644_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,7 +2685,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-412>
+          <http://model.geneontology.org/CHEBI_145644_RXN3O-412>
 ] .
 
 <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
@@ -2697,7 +2697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2713,7 +2713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,6 +2724,34 @@
           <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_145630_RXN3O-413>
+        a       <http://purl.obolibrary.org/obo/CHEBI_145630> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002413_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
@@ -2732,7 +2760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2743,28 +2771,22 @@
           <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_28067_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2774,7 +2796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2792,11 +2814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_53742_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2804,32 +2826,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57527_RXN3O-379>
+          <http://model.geneontology.org/CHEBI_53742_RXN3O-378>
 ] .
 
-<http://model.geneontology.org/8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_61895>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_2.7.8.15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2841,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,17 +2869,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/76caf99b-7c44-416f-9c15-1b759ef4f7c2_RXN3O-11> , <http://model.geneontology.org/5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259> ;
+                <http://model.geneontology.org/CHEBI_59091_RXN3O-11> , <http://model.geneontology.org/CHEBI_15809_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
+                <http://model.geneontology.org/CHEBI_37637_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-411> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2883,11 +2891,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_58189_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2895,7 +2903,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN>
+          <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
@@ -2907,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2915,34 +2923,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002411_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_145644_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2956,7 +2953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,23 +2964,12 @@
           <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_7ae87e1c-9314-4357-a81d-86dcd42498d6_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000066_reaction_RXN3O-3_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2994,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3005,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3019,7 +3005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3054,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3063,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3074,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3088,7 +3074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3108,17 +3094,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259> , <http://model.geneontology.org/CHEBI_57525_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-411> , <http://model.geneontology.org/CHEBI_37637_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ba7af82c-24c6-4cdc-8a0c-83afd7cd4b25_RXN3O-411> , <http://model.geneontology.org/CHEBI_16214_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_145597_RXN3O-411> , <http://model.geneontology.org/CHEBI_16214_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-412> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3135,7 +3121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3151,7 +3137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3166,11 +3152,69 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_145644_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-413> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_145644_RXN3O-412>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_53742_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-378> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_53742_RXN3O-378>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_37637>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_53023_RXN3O-291>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_53023> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(6)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,61 +3223,6 @@
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
-] .
-
-<http://model.geneontology.org/5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-378> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-413> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412>
 ] .
 
 <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -3245,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lipid-linked oligosaccharide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3262,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3277,11 +3266,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3289,49 +3278,27 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378>
+          <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(7)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(8)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(8)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(9)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002411_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002413_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-259>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_92ed5ae5-4551-40b6-8f8b-f6b7ccc355c0_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-24_2.4.1.141-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3342,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3355,7 +3322,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_37637_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3366,7 +3344,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_CHEBI_61895_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3380,7 +3369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3391,17 +3380,6 @@
           <http://model.geneontology.org/CHEBI_58223_2.4.1.141-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002411_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
@@ -3410,7 +3388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3429,7 +3407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3440,29 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_847718e9-db40-4695-a692-a04b9160265a_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3495,7 +3451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3505,11 +3461,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_CHEBI_53022_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3517,18 +3473,51 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN>
+          <http://model.geneontology.org/CHEBI_53022_2.4.1.131-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002413_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_f2ec75a1-06cc-40a3-944b-ca001e92b131_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_CHEBI_59088_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_28067_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3536,21 +3525,38 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
+          <http://model.geneontology.org/CHEBI_28067_2.4.1.132-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/CHEBI_15809_RXN3O-291>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15809> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_CHEBI_16214_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3558,22 +3564,39 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412>
+          <http://model.geneontology.org/CHEBI_16214_RXN3O-412>
 ] .
+
+<http://model.geneontology.org/7bdeeb17-bb1c-483f-b64c-eb894649d8a9_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(4)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Provides Input For Rule. The relation 'a dolichyl &beta;-D-mannosyl phosphate + Man(6)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(7)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(7)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(8)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002411_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002413_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3588,7 +3611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3602,7 +3625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3615,7 +3638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3623,12 +3646,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_CHEBI_15809_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3639,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3653,7 +3676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3664,24 +3687,15 @@
           <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_57527_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,8 +3703,17 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4050a249-f7fe-40bf-bc93-5c6cb09af629_RXN3O-378>
+          <http://model.geneontology.org/CHEBI_57527_RXN3O-379>
 ] .
+
+<http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57527> ;
@@ -3701,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3721,7 +3744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3733,11 +3756,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_CHEBI_37637_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3745,7 +3768,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259>
+          <http://model.geneontology.org/CHEBI_37637_RXN3O-259>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3756,7 +3779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3767,17 +3790,6 @@
           <http://model.geneontology.org/reaction_2.4.1.141-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002411_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3787,13 +3799,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_145630>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3803,7 +3818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3814,23 +3829,12 @@
           <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_c39a4d48-72b5-4e3f-8db2-46f9b7a0c239_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_CHEBI_145597_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3845,17 +3849,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f4a6dbdc-6bdc-491c-8f9f-7784a34e5f65_2.4.1.131-RXN> , <http://model.geneontology.org/bd41d81e-c35a-4ede-adec-1b7ddd2468c2_RXN3O-291> ;
+                <http://model.geneontology.org/CHEBI_53022_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_15809_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-291> , <http://model.geneontology.org/f8cd9545-5855-4fbf-8914-6358840b0e2c_RXN3O-291> ;
+                <http://model.geneontology.org/CHEBI_53023_RXN3O-291> , <http://model.geneontology.org/CHEBI_16214_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-3> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3865,17 +3869,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'a dolichyl &beta;-D-glucosyl phosphate + Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-glucosyl phosphate + Glc(1)Man(9)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Glc(2)Man(9)GlcNac(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002411_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002413_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3887,7 +3891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3898,7 +3902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3912,7 +3916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,7 +3935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3947,28 +3951,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/5f9d87b1-c58f-4732-b512-c7fe9bda0df7_RXN3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_59088>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000005528>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3978,11 +3968,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_53022_2.4.1.131-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_53022> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(5)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-412>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0042283> ;
@@ -3993,17 +4000,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57525_RXN3O-412> , <http://model.geneontology.org/854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_145597_RXN3O-411> , <http://model.geneontology.org/CHEBI_57525_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412> , <http://model.geneontology.org/CHEBI_16214_RXN3O-412> ;
+                <http://model.geneontology.org/CHEBI_145644_RXN3O-412> , <http://model.geneontology.org/CHEBI_16214_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-413> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4015,11 +4022,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_CHEBI_15809_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4027,7 +4034,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a845ab77-9fd0-4bff-8437-af0f9cf4bea1_RXN3O-11>
+          <http://model.geneontology.org/CHEBI_15809_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
@@ -4039,7 +4046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4047,47 +4054,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_53022>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002411_RXN3O-412_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-379_BFO_0000066_reaction_RXN3O-379_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/df58bf29-4a78-4024-a457-02168ed2cf74_RXN3O-412>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_15809>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005528> ;
@@ -4096,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4109,7 +4094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4118,32 +4103,15 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(2)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_145630_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4151,18 +4119,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16214_RXN3O-413>
+          <http://model.geneontology.org/CHEBI_145630_RXN3O-413>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0042283>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_df7aad3c-370b-4788-ad36-cae95dc92f2c_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_CHEBI_61895_RXN3O-9818_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4173,7 +4141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4187,7 +4155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4198,17 +4166,6 @@
           <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004993> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4216,7 +4173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4227,17 +4184,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
@@ -4246,7 +4192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4257,6 +4203,34 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
+<http://model.geneontology.org/CHEBI_15809_RXN3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15809> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_CHEBI_59088_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
@@ -4265,7 +4239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4284,7 +4258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4317,7 +4291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4325,11 +4299,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_37637_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4337,19 +4311,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
+          <http://model.geneontology.org/CHEBI_37637_RXN3O-259>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller>
         a       <http://identifiers.org/sgd/S000005163> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4358,24 +4321,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28233> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
         a       <http://purl.obolibrary.org/obo/CHEBI_57525> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4386,7 +4338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4394,12 +4346,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.7.8.15-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_61895_RXN3O-9818>
+        a       <http://purl.obolibrary.org/obo/CHEBI_61895> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(1)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002413_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4413,7 +4393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4427,23 +4407,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_CHEBI_15809_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002411_RXN3O-413_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_CHEBI_16214_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4456,7 +4436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4469,7 +4449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4479,11 +4459,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4491,15 +4471,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN>
+          <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_CHEBI_53022_2.4.1.131-RXN_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4513,7 +4504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4524,15 +4515,23 @@
           <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller>
 ] .
 
-<http://model.geneontology.org/163cbe7f-335a-421b-a7a1-50b782606d2f_2.4.1.132-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_CHEBI_53742_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002333_MONOMER3O-256_RXN3O-11_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4546,7 +4545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4562,18 +4561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_5395ffe3-c478-46e5-891d-bbd008f6296e_RXN3O-259_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4584,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4595,7 +4583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4606,7 +4594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4621,7 +4609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4638,7 +4626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4646,33 +4634,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_1ee9c7f0-7825-4911-bfb2-79bd9d6c8759_RXN3O-379_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_15809_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15809> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4682,7 +4673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4702,11 +4693,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/38f2d8e3-b789-4775-8db0-114c15732fbc_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_53742_RXN3O-378>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_53742> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(3)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4715,7 +4740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4726,7 +4751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4743,7 +4768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4763,7 +4788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4776,7 +4801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4790,7 +4815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4809,7 +4834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4829,7 +4854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4842,7 +4867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4857,7 +4882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4865,12 +4890,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002413_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4878,40 +4914,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" , "Provides Input For Rule. The relation 'GDP-&alpha;-D-mannose + Man(4)GlcNAc(2)-PP-Dol &rarr; GDP + Man(5)GlcNAc(2)-PP-Dol' 'null' 'a dolichyl &beta;-D-mannosyl phosphate + Man(5)GlcNAc(2)-PP-Dol &rarr; a dolichyl phosphate + Man(6)GlcNAc(2)-PP-Dol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002411_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002413_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN3O-291>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_f56e7bde-caf9-44e3-b77a-62655be32ae0_RXN3O-378_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4920,7 +4945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4934,7 +4959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4945,18 +4970,15 @@
           <http://model.geneontology.org/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_CHEBI_15809_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4964,7 +4986,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d08d5f38-dde9-48fc-8cd1-7ad512636d89_RXN3O-291>
+          <http://model.geneontology.org/CHEBI_15809_RXN3O-3>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -4972,7 +4994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4986,7 +5008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5005,7 +5027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5035,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5051,7 +5073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5074,15 +5096,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/1686f98c-06ea-4fdc-bc0a-18b834d48772_RXN3O-412> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/CHEBI_145644_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8da13775-d9df-4ab8-a12a-a7c945a3e8d4_RXN3O-413> , <http://model.geneontology.org/CHEBI_16214_RXN3O-413> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-413> , <http://model.geneontology.org/CHEBI_145630_RXN3O-413> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5094,11 +5116,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_CHEBI_59088_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5106,18 +5128,21 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7ac670b3-263f-4508-92ae-468bb59034b3_RXN3O-3>
+          <http://model.geneontology.org/CHEBI_59088_RXN3O-3>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_53023>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_CHEBI_53023_RXN3O-291_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5125,30 +5150,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fca9712b-d55a-42bf-9cfa-dae08a75ca65_RXN3O-3>
+          <http://model.geneontology.org/CHEBI_53023_RXN3O-291>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002411_RXN3O-11_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_854001f4-bd40-4746-9c77-b37d0d411124_RXN3O-411_SGD_PWY_YeastPathways_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/f2ec75a1-06cc-40a3-944b-ca001e92b131_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://identifiers.org/sgd/S000004993>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5162,17 +5168,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/2e5dfe1e-d8a3-4d8b-bc58-ad19a4ed26d2_RXN3O-9818> ;
+                <http://model.geneontology.org/CHEBI_61895_RXN3O-9818> , <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/57ff4c1d-26a1-4a83-ad75-414834cac731_2.4.1.132-RXN> , <http://model.geneontology.org/d018c7da-1515-4b95-b5cd-e915969b26d8_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
+                <http://model.geneontology.org/38f2d8e3-b789-4775-8db0-114c15732fbc_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_28067_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-378> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUDEG-I-PWY-1.ttl
+++ b/models/YeastPathways_GLUDEG-I-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12,7 +12,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,23 +824,23 @@
           <http://model.geneontology.org/YBR006W-MONOMER_RXN0-5293_controller>
 ] .
 
-<http://model.geneontology.org/reaction_RXN0-5293_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-5293_RO_0002233_CHEBI_13390_RXN0-5293_SGD_PWY_YeastPathways_GLUDEG-I-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN0-5293_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1204,7 +1204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1226,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_GLUGLNSYN-PWY.ttl
+++ b/models/YeastPathways_GLUGLNSYN-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamate biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUNH3-PWY.ttl
+++ b/models/YeastPathways_GLUNH3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate biosynthesis from ammonia - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLUT-REDOX2-PWY.ttl
+++ b/models/YeastPathways_GLUT-REDOX2-PWY.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,9 +155,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN> , <http://model.geneontology.org/0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN> , <http://model.geneontology.org/CHEBI_17792_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN> , <http://model.geneontology.org/5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17021_GSHTRAN-RXN> , <http://model.geneontology.org/CHEBI_18140_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller> , <http://model.geneontology.org/YLL060C-MONOMER_GSHTRAN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,17 +201,6 @@
 <http://purl.obolibrary.org/obo/GO_0006749>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58297>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -223,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,16 +270,22 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_17021_GSHTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17021> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glutathione-<i>S</i>-conjugate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUT-REDOX2-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -300,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,11 +378,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_CHEBI_18140_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +390,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_18140_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
@@ -410,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,35 +416,15 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "HX" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,17 +463,6 @@
           <http://model.geneontology.org/PRODISULFREDUCT-A-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
@@ -507,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,6 +610,15 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
@@ -654,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,21 +638,12 @@
           <http://model.geneontology.org/CHEBI_16240_GLUTATHIONE-PEROXIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YLL060C-MONOMER_GSHTRAN-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -689,11 +653,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_CHEBI_17021_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,11 +665,14 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5ea1c58e-5b44-4998-9c4a-50bfe0311e3e_GSHTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_17021_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_17021>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -715,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +712,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -784,23 +762,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_57925>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002411_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_18140_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_18140> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "HX" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUT-REDOX2-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002413_GLUTATHIONE-PEROXIDASE-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -809,23 +793,12 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000066_reaction_GSHTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_BFO_0000050_YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,6 +822,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_BFO_0000066_reaction_GSHTRAN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004362>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -861,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,12 +856,29 @@
           <http://model.geneontology.org/YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_17792_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17792> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "RX" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -888,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -900,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,13 +921,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin redox reactions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://purl.obolibrary.org/obo/CHEBI_18140>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -936,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,26 +962,15 @@
           <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +978,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN>
+          <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_GLUT-REDOX2-PWY/YeastPathways_GLUT-REDOX2-PWY>
@@ -986,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1003,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,28 +1063,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60944> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/0ea5b1d4-f73c-4a48-a220-b2e5dc99b423_GSHTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "RX" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1098,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1192,12 +1179,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_17792_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YBR244W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1242,7 +1240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,11 +1258,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_CHEBI_17792_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1270,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-REDUCT-NADPH-RXN>
+          <http://model.geneontology.org/CHEBI_17792_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1286,7 +1284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1322,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1349,11 +1347,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17792>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/Red-Glutaredoxins_PRODISULFREDUCT-A-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -1364,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1383,7 +1384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1503,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1546,22 +1547,16 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9903dc9d-e4df-425a-94bb-6536300e6070_GSHTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glutathione-<i>S</i>-conjugate" ;
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_CHEBI_18140_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004362> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1582,7 +1577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1608,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1624,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1643,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1649,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_CHEBI_17021_GSHTRAN-RXN_SGD_PWY_YeastPathways_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1712,7 +1718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_GLUTATHIONESYN-PWY.ttl
+++ b/models/YeastPathways_GLUTATHIONESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -31,16 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_GLUTCYSLIG-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -53,13 +44,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYSmallMolecule59742> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_GLUTCYSLIG-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLUTATHIONE-SYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,22 +208,16 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYSmallMolecule59654> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58173_GLUTCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58173> ;
@@ -234,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,23 +236,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_57925_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYSmallMolecule59654> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002333_YOL049W-MONOMER_GLUTATHIONE-SYN-RXN_controller_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,6 +396,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GLUTATHIONE-SYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GLUTATHIONE-SYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004363> ;
@@ -414,24 +425,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUTATHIONESYN-PWYBiochemicalReaction59592> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002234_CHEBI_58173_GLUTCYSLIG-RXN_SGD_PWY_YeastPathways_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYCLEAV-PWY.ttl
+++ b/models/YeastPathways_GLYCLEAV-PWY.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0019464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -16,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -29,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,30 +46,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYProtein22619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57945_RXN-8629>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -91,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,11 +75,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_20502_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +87,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
@@ -123,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -131,11 +103,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +115,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629>
+          <http://model.geneontology.org/CHEBI_57305_GCVP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -157,21 +129,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/4971a536-db23-4b90-8cb4-f3a04192b2f5_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_57540_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +168,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN>
+          <http://model.geneontology.org/CHEBI_57540_RXN-8629>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
@@ -187,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -202,23 +191,40 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/CHEBI_15804_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
+                <http://model.geneontology.org/CHEBI_16882_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/GCVT-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYBiochemicalReaction22665> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_20502_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -235,11 +241,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22655> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_16882_GCVP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16882> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -255,17 +278,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN> , <http://model.geneontology.org/e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN> ;
+                <http://model.geneontology.org/CHEBI_16882_GCVP-RXN> , <http://model.geneontology.org/4971a536-db23-4b90-8cb4-f3a04192b2f5_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> , <http://model.geneontology.org/fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN> , <http://model.geneontology.org/b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN> ;
+                <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> , <http://model.geneontology.org/CHEBI_20502_GCVT-RXN> , <http://model.geneontology.org/CHEBI_16194_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-8629> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,11 +300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_16194_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,18 +312,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVT-RXN>
+          <http://model.geneontology.org/CHEBI_16194_GCVT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15804_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,19 +331,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GCVP-RXN>
+          <http://model.geneontology.org/CHEBI_15804_RXN-8629>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -330,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -354,6 +366,23 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/CHEBI_15804_RXN-8629>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15804> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -368,11 +397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_57540_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_16194_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,25 +409,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_RXN-8629>
+          <http://model.geneontology.org/CHEBI_16194_GCVT-RXN>
 ] .
-
-<http://model.geneontology.org/fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-8629>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -409,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -445,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,61 +473,58 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+          "Provides Input For Rule. The relation 'glycine + a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &harr; CO<SUB>2</SUB> + a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine' 'null' 'a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine + a tetrahydrofolate &harr; a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + a 5,10-methylenetetrahydrofolate + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002411_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002413_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GCVT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002411_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_15804_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002333_YFL018C-MONOMER_RXN-8629_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_16194_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16882>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -524,11 +533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_4971a536-db23-4b90-8cb4-f3a04192b2f5_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +545,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN>
+          <http://model.geneontology.org/4971a536-db23-4b90-8cb4-f3a04192b2f5_GCVT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -547,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +608,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_15804_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -607,17 +627,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004148>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -627,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -672,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -680,17 +689,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+          "Provides Input For Rule. The relation 'a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine + a tetrahydrofolate &harr; a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + a 5,10-methylenetetrahydrofolate + ammonium' 'null' 'a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &harr; a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002411_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002413_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -706,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,20 +742,6 @@
           <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_e43c2061-ae53-49cc-a136-da83295d3259_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.obolibrary.org/obo/GO_0004375>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -755,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -776,11 +771,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_CHEBI_16882_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,8 +783,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN>
+          <http://model.geneontology.org/CHEBI_16882_GCVP-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller>
         a       <http://identifiers.org/sgd/S000002426> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -798,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -814,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,8 +823,16 @@
           <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_4971a536-db23-4b90-8cb4-f3a04192b2f5_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-8629>
         a       <http://purl.obolibrary.org/obo/GO_0004148> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -837,9 +843,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_16194_GCVT-RXN> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> , <http://model.geneontology.org/a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_15804_RXN-8629> , <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -847,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,11 +865,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +877,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629>
+          <http://model.geneontology.org/CHEBI_57945_RXN-8629>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002333_YDR019C-MONOMER_GCVT-RXN_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
@@ -879,18 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -902,25 +897,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002411_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_20502_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/4eecd42f-0ff0-4005-a60a-cf213bac24c5_RXN-8629>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/GO_0004047>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -930,6 +919,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0019464>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16882_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,11 +957,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16882_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN>
+          <http://model.geneontology.org/CHEBI_16882_GCVP-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -988,28 +988,6 @@
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_5aea9989-2ce8-44a4-92ac-daf4a5e6b328_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_GCVP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -1020,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,6 +1025,17 @@
           <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002413_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
@@ -1055,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,15 +1055,29 @@
           <http://model.geneontology.org/YeastPathways_GLYCLEAV-PWY/YeastPathways_GLYCLEAV-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_CHEBI_16882_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15804>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_57945_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_CHEBI_15804_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,7 +1085,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN-8629>
+          <http://model.geneontology.org/CHEBI_15804_RXN-8629>
 ] .
 
 <http://model.geneontology.org/CHEBI_57305_GCVP-RXN>
@@ -1094,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,10 +1105,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002413_RXN-8629_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002333_YMR189W-MONOMER_GCVP-RXN_controller_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
@@ -1113,14 +1130,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://purl.obolibrary.org/obo/CHEBI_16194>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1131,30 +1148,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine cleavage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/a7f13410-322a-4c21-915b-f2cad422ddba_RXN-8629>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_GCVP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,15 +1173,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_b8949e9c-3d67-4eb0-b281-a55f734b7e8b_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GCVT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28938_GCVT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_CHEBI_16194_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1191,30 +1213,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GCVT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fd5312ca-65e2-4156-9975-7b862c7d5584_GCVT-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,29 +1228,12 @@
           <http://model.geneontology.org/CHEBI_16526_GCVP-RXN>
 ] .
 
-<http://model.geneontology.org/945ebb2a-2b8e-4c51-b18d-e47dda6ce554_GCVP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_CHEBI_16526_GCVP-RXN_SGD_PWY_YeastPathways_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1258,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,5 +1294,19 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-8629>
 ] .
 
-<http://model.geneontology.org/d1ced68b-7b7c-44e2-a232-c43f7031b473_GCVP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/CHEBI_16194_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16194> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_GLYCOCAT-YEAST-PWY.ttl
+++ b/models/YeastPathways_GLYCOCAT-YEAST-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,11 +32,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_f77be747-8c95-4508-a5f1-9a9b380a86a2_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023>
+          <http://model.geneontology.org/f77be747-8c95-4508-a5f1-9a9b380a86a2_RXN-9023>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002413_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,15 +131,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN-9023_BFO_0000066_reaction_RXN-9023_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -171,12 +168,23 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_CHEBI_28912_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,11 +235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_28912_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +247,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/CHEBI_28912_GLYCOPHOSPHORYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -247,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -262,17 +270,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002411_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller>
         a       <http://identifiers.org/sgd/S000006388> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -280,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,11 +289,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +301,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN>
+          <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -312,7 +309,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_be2237b1-ca04-49da-8bb1-1c12c1e0804f_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,6 +381,9 @@
           <http://model.geneontology.org/YKL127W-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -382,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,8 +401,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_28912_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -401,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -571,11 +590,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_28912_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +602,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN-9025>
+          <http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_BFO_0000066_reaction_AMYLOMALT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -591,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,17 +618,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" , "Provides Input For Rule. The relation 'a glycogen + phosphate &rarr; an &alpha;-limit dextrin + &alpha;-D-glucopyranose 1-phosphate' 'null' 'an &alpha;-limit dextrin &harr; a &alpha;-limit dextrin with short branches' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002411_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002413_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -621,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -661,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -680,17 +699,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+          "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n phosphate &rarr; n &alpha;-D-glucopyranose 1-phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -708,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +799,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_RXN-9024> ;
+                <http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_4167_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -788,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,11 +841,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_28912_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +853,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN>
+          <http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -845,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,6 +877,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58601>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_28912_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AMYLOMALT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -876,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -891,11 +921,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_be2237b1-ca04-49da-8bb1-1c12c1e0804f_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +933,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023>
+          <http://model.geneontology.org/be2237b1-ca04-49da-8bb1-1c12c1e0804f_RXN-9023>
 ] .
 
 <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
@@ -911,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -923,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,18 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,15 +1005,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_24384_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/CHEBI_28912_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-9023> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,17 +1041,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17306>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_61993_AMYLOMALT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_61993> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1042,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1149,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1176,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,34 +1195,12 @@
           <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002333_YPR184W-MONOMER_AMYLOMALT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,15 +1223,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1262,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,11 +1296,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_CHEBI_58601_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1308,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4038_RO_0002413_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -1333,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1478,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,18 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1520,13 +1492,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27808> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_f77be747-8c95-4508-a5f1-9a9b380a86a2_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/3.2.1.3-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004339> ;
@@ -1549,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1568,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1581,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1597,7 +1580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1616,7 +1599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1647,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,8 +1641,8 @@
           <http://model.geneontology.org/YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/CHEBI_28912_GLYCOPHOSPHORYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_28912> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1667,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,8 +1658,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/CHEBI_28912>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1686,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1702,7 +1685,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/be2237b1-ca04-49da-8bb1-1c12c1e0804f_RXN-9023>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_CHEBI_28912_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1712,11 +1709,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_43474_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1721,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN>
+          <http://model.geneontology.org/CHEBI_43474_RXN-9025>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -1732,7 +1729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1773,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1784,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1810,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,11 +1841,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_CHEBI_28912_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,8 +1853,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/CHEBI_28912_GLYCOPHOSPHORYL-RXN>
 ] .
+
+<http://model.geneontology.org/f77be747-8c95-4508-a5f1-9a9b380a86a2_RXN-9023>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a &alpha;-limit dextrin with short branches" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1867,7 +1881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1893,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1910,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,7 +1937,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1977,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/465b6759-ca3e-445f-8516-796cf1a222f6_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_43474_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58601_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1951,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,7 +2003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1983,7 +2019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1995,7 +2031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2015,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2028,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2060,11 +2096,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_4167_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_CHEBI_28912_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2108,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
+          <http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000066_reaction_3.2.1.33-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
@@ -2080,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2114,19 +2150,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1cfe48fe-e981-49ad-b001-2d6b08079fa8_RXN-9023> , <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/be2237b1-ca04-49da-8bb1-1c12c1e0804f_RXN-9023> , <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN-9024> , <http://model.geneontology.org/RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/3.2.1.3-RXN> ;
+                <http://model.geneontology.org/3.2.1.3-RXN> , <http://model.geneontology.org/RXN-9025> , <http://model.geneontology.org/RXN-9024> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2142,7 +2176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2153,9 +2187,6 @@
           <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
 ] .
 
-<http://model.geneontology.org/ea25a482-01a3-4956-b436-9c17e59d4a25_3.2.1.33-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
@@ -2164,7 +2195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2204,7 +2235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2226,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,12 +2268,29 @@
           <http://model.geneontology.org/3.2.1.33-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_28912_3.2.1.33-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_28912> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a debranched &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,28 +2320,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a &alpha;-limit dextrin with short branches" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4167> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2304,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2317,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2328,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2343,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2356,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2367,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2381,7 +2412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2411,12 +2442,23 @@
           <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_CHEBI_28912_3.2.1.33-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2428,7 +2470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2457,40 +2499,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002413_RXN-9023_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_61993_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002411_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2498,40 +2529,29 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+          "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n H<sub>2</sub>O &rarr; n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002413_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-9024>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2542,7 +2562,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000066_reaction_RXN3O-4038_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4038_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002234_CHEBI_61993_AMYLOMALT-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2554,7 +2607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2565,17 +2618,6 @@
           <http://model.geneontology.org/CHEBI_24384_RXN3O-4038>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
@@ -2584,7 +2626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2604,7 +2646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2620,7 +2662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2636,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2651,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2683,9 +2725,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/cd96b8b3-b7b4-4dc6-be00-a79c122e033d_GLYCOPHOSPHORYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_28912_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9d1581d0-602c-4255-b6c9-a81e71cab33a_RXN-9023> ;
+                <http://model.geneontology.org/f77be747-8c95-4508-a5f1-9a9b380a86a2_RXN-9023> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_RXN-9023_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2693,7 +2735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2709,7 +2751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,9 +2762,6 @@
           <http://model.geneontology.org/CHEBI_15377_3.2.1.3-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_4167>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
@@ -2731,7 +2770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,45 +2800,26 @@
           <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9025_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002411_RXN-9024_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_4167>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002333_YPR184W-MONOMER_RXN-9023_controller_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2814,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2839,7 +2859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2855,7 +2875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2869,7 +2889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2888,7 +2908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2918,7 +2938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2934,7 +2954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,23 +2968,6 @@
 <http://identifiers.org/sgd/S000001361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/818d6267-d97f-4bef-9b99-719fc902ab9e_3.2.1.33-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://identifiers.org/sgd/S000004711>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2977,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2985,23 +2988,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_28654472-3f02-41fd-9809-9cb9573d84a5_GLYCOPHOSPHORYL-RXN_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_YeastPathways_GLYCOCAT-YEAST-PWY/YeastPathways_GLYCOCAT-YEAST-PWY_SGD_PWY_YeastPathways_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3012,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3021,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_GLYCOLYSIS.ttl
+++ b/models/YeastPathways_GLYCOLYSIS.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -697,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1432,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1614,7 +1614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1697,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1769,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1840,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1856,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1942,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1977,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1990,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2007,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2050,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,7 +2105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2134,7 +2134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2167,7 +2167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2183,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2196,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2212,7 +2212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2231,7 +2231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2280,7 +2280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2325,7 +2325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2344,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2358,7 +2358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2388,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycolysis I (from glucose 6-phosphate) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2482,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2498,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2512,7 +2512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2531,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2551,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2567,7 +2567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2586,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2611,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2626,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2642,7 +2642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2672,7 +2672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2688,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2697,7 +2697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2711,7 +2711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2747,7 +2747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2761,7 +2761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2784,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,7 +2800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2819,7 +2819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2833,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2847,7 +2847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2893,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2914,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2927,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2936,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2950,7 +2950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2966,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2978,7 +2978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2994,7 +2994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3005,7 +3005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3016,7 +3016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3031,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3047,7 +3047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3066,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3082,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3096,7 +3096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3153,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3167,7 +3167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3186,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3217,7 +3217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3230,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3247,7 +3247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3263,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3277,7 +3277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3296,7 +3296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3309,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3331,7 +3331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3364,7 +3364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3397,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3425,7 +3425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3444,7 +3444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3463,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3477,7 +3477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3493,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3504,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3519,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3536,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3552,7 +3552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3579,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3613,7 +3613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3629,7 +3629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3640,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3655,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3674,7 +3674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3685,7 +3685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3696,7 +3696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3710,7 +3710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,7 +3728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3747,7 +3747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3788,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3804,7 +3804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3820,7 +3820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3831,7 +3831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3848,7 +3848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,7 +3867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3883,7 +3883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3897,7 +3897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3916,7 +3916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3935,7 +3935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3957,7 +3957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3973,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3985,7 +3985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4015,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4032,7 +4032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYOXYLATE-BYPASS.ttl
+++ b/models/YeastPathways_GLYOXYLATE-BYPASS.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,17 +1302,6 @@
           <http://model.geneontology.org/YIR031C-MONOMER_MALSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
@@ -1321,7 +1310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1331,6 +1320,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YER065C-MONOMER_ISOCIT-CLEAV-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_36655_ISOCIT-CLEAV-RXN_SGD_PWY_YeastPathways_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16947>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1388,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1465,7 +1465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1593,7 +1593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1615,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1672,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1705,7 +1705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1781,7 +1781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,7 +1800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1816,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1830,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1972,7 +1972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1991,7 +1991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2049,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2062,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,7 +2095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2123,7 +2123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2173,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2184,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2198,7 +2198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2233,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2247,7 +2247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2272,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2295,7 +2295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2314,7 +2314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2333,7 +2333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2358,7 +2358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2372,7 +2372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2383,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2446,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2459,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2476,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2489,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2501,7 +2501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2517,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2553,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2572,7 +2572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2609,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2625,7 +2625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2671,7 +2671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2682,7 +2682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2693,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2719,7 +2719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYSYN-ALA-PWY.ttl
+++ b/models/YeastPathways_GLYSYN-ALA-PWY.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYSYN-PWY.ttl
+++ b/models/YeastPathways_GLYSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -16,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,11 +59,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_64024fe7-d070-4d0d-a5b2-a619afc38de9_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,36 +71,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/64024fe7-d070-4d0d-a5b2-a619afc38de9_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004048> ;
@@ -109,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,6 +98,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/64024fe7-d070-4d0d-a5b2-a619afc38de9_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -140,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -251,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,15 +251,26 @@
           <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57305>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57305>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_64024fe7-d070-4d0d-a5b2-a619afc38de9_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -314,11 +314,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -355,15 +355,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1d76c057-188a-4629-ab17-5a83259c3201_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/64024fe7-d070-4d0d-a5b2-a619afc38de9_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,29 +371,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/8b39883c-c19f-4300-95b1-ef1b92062529_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,13 +420,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_GLYSYN-PWY" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -455,11 +441,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +453,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_GLYSYN-PWY>
@@ -475,11 +461,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -493,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -519,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_GLYSYN-THR-PWY.ttl
+++ b/models/YeastPathways_GLYSYN-THR-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_HEME-BIOSYNTHESIS-II.ttl
+++ b/models/YeastPathways_HEME-BIOSYNTHESIS-II.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -333,7 +333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "heme <i>b</i> biosynthesis I (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -825,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1243,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1337,7 +1337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1384,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1398,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1426,7 +1426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_HEXPPSYN-PWY-2.ttl
+++ b/models/YeastPathways_HEXPPSYN-PWY-2.ttl
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,22 +128,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -154,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,16 +156,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002233_CHEBI_128769_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HEXPPSYN-PWY-2" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_29888_RXN-8813>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -969,7 +969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1039,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1125,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "hexaprenyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,42 +1242,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_175763>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FPPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1287,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,13 +1270,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_128769_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FPPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" , "Provides Input For Rule. The relation 'dimethylallyl diphosphate + isopentenyl diphosphate &rarr; geranyl diphosphate + diphosphate' 'null' 'geranyl diphosphate + isopentenyl diphosphate &rarr; (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002413_FPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,6 +1305,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/FPPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004311> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,23 +1344,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_128769_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1369,6 +1358,17 @@
 <http://purl.obolibrary.org/obo/GO_0004161>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GPPSYN-RXN_BFO_0000050_YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2_SGD_PWY_YeastPathways_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_HEXPPSYN-PWY-2/YeastPathways_HEXPPSYN-PWY-2>
         a       <http://purl.obolibrary.org/obo/GO_0006744> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1406,7 +1406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1450,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1466,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1490,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1568,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1624,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1678,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1698,7 +1698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1725,7 +1725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1750,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1775,7 +1775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_HISTSYN-PWY.ttl
+++ b/models/YeastPathways_HISTSYN-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,12 +191,12 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,23 +221,23 @@
           <http://model.geneontology.org/YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002413_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002234_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -251,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,12 +547,12 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,12 +575,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_RO_0002233_CHEBI_58278_GLUTAMIDOTRANS-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_IMIDPHOSDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -906,7 +906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,6 +920,9 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
@@ -928,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,15 +942,12 @@
           <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002234_CHEBI_59457_HISTPRATPHYD-RXN_SGD_PWY_YeastPathways_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1017,7 +1017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1201,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1310,7 +1310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1376,7 +1376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1447,7 +1447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,7 +1466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,7 +1502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,7 +1521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1613,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,7 +1712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1765,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1815,7 +1815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1901,7 +1901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,7 +1920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1961,7 +1961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +1995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2017,7 +2017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,18 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2058,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,6 +2058,28 @@
           <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_RO_0002333_YIL020C-MONOMER_PRIBFAICARPISOM-RXN_controller_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58017> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2078,24 +2089,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24363> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HISTOLDEHYD-RXN_BFO_0000050_YeastPathways_HISTSYN-PWY/YeastPathways_HISTSYN-PWY_SGD_PWY_YeastPathways_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2105,7 +2105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2125,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2138,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,7 +2181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2206,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,7 +2260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2279,7 +2279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2309,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2333,7 +2333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2348,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2376,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2392,7 +2392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2418,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,7 +2434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2453,7 +2453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2469,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2483,7 +2483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2502,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2518,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2529,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2546,7 +2546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2557,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2568,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2580,7 +2580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,7 +2602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2640,7 +2640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2656,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2670,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2695,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2708,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2722,7 +2722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2753,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2767,7 +2767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,7 +2786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2806,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2819,7 +2819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2834,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-histidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2847,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2861,7 +2861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2886,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2897,7 +2897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2912,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2927,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2943,7 +2943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2962,7 +2962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2980,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2993,7 +2993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3004,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3018,7 +3018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3034,7 +3034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3045,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3059,7 +3059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3075,7 +3075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3086,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3104,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3117,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3131,7 +3131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3186,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,7 +3208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3228,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3248,7 +3248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3270,7 +3270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3289,7 +3289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3305,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3319,7 +3319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3338,7 +3338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3349,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3364,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3407,7 +3407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3418,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3435,7 +3435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3465,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3481,7 +3481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3503,7 +3503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3519,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3531,7 +3531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3551,7 +3551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3576,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3596,7 +3596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3612,7 +3612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3631,7 +3631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3688,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3699,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3712,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3725,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3739,7 +3739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_HOMOCYS-CYS-CONVERT.ttl
+++ b/models/YeastPathways_HOMOCYS-CYS-CONVERT.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "homocysteine and cysteine interconversion - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -112,7 +112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -807,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1397,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1488,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1548,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_HOMOCYSDEGR-PWY-1.ttl
+++ b/models/YeastPathways_HOMOCYSDEGR-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-cysteine biosynthesis III (from L-homocysteine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_HOMOSER-THRESYN-PWY.ttl
+++ b/models/YeastPathways_HOMOSER-THRESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,17 +616,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -636,13 +625,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOSER-THRESYN-PWYSmallMolecule73060> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_HOMOSER-THRESYN-PWY/YeastPathways_HOMOSER-THRESYN-PWY_SGD_PWY_YeastPathways_HOMOSER-THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSER-THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_HOMOSERSYN-PWY.ttl
+++ b/models/YeastPathways_HOMOSERSYN-PWY.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homoserine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -826,7 +826,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -834,17 +845,6 @@
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002413_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -854,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -884,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,6 +953,17 @@
           <http://model.geneontology.org/YeastPathways_HOMOSERSYN-PWY/YeastPathways_HOMOSERSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
@@ -961,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,23 +983,12 @@
           <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002333_YDR158W-MONOMER_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_controller_SGD_PWY_YeastPathways_HOMOSERSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1047,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_ILEUSYN-PWY-1.ttl
+++ b/models/YeastPathways_ILEUSYN-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -841,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -855,7 +855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,7 +935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,7 +1114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-isoleucine biosynthesis I (from threonine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1183,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1562,7 +1562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1719,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1772,7 +1772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1820,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,7 +1853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1900,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1925,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1939,7 +1939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1958,7 +1958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1981,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_IPPSYN-PWY.ttl
+++ b/models/YeastPathways_IPPSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,9 +264,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_36464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0004421>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -274,13 +271,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYProtein26128> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/GO_0004421>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -917,7 +917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,23 +947,23 @@
           <http://model.geneontology.org/CHEBI_15377_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_YeastPathways_IPPSYN-PWY/YeastPathways_IPPSYN-PWY_SGD_PWY_YeastPathways_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1062,18 +1062,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1082,12 +1082,12 @@
 <http://identifiers.org/sgd/S000006038>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_PWY_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_RO_0002413_IPPISOM-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1157,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1184,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,20 +1350,6 @@
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_15378_MEVALONATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1373,13 +1359,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYSmallMolecule25992> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_MEVALONATE-KINASE-RXN_SGD_PWY_YeastPathways_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004163> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1526,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1574,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,7 +1593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1637,7 +1637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,7 +1686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1703,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1719,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,7 +1741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1919,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1976,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2041,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2060,7 +2060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2080,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2093,7 +2093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2107,7 +2107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2137,7 +2137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2171,7 +2171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2231,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2245,7 +2245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2267,7 +2267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2286,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2309,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2333,7 +2333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2359,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2368,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2382,7 +2382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2402,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2418,7 +2418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2438,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2465,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2498,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2514,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2528,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2548,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2593,7 +2593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2633,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2649,7 +2649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2663,7 +2663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,25 +2692,6 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
@@ -2722,13 +2703,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=IPPSYN-PWYSmallMolecule26032> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_IPPSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
+] .
 
 <http://identifiers.org/sgd/S000004540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2738,7 +2738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2753,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2766,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2777,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2788,7 +2788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2797,7 +2797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_LEUSYN-PWY-1.ttl
+++ b/models/YeastPathways_LEUSYN-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,13 +225,13 @@
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN> , <http://model.geneontology.org/CHEBI_57287_2-ISOPROPYLMALATESYN-RXN> , <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller> , <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller> ;
+                <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller> , <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-13163> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-leucine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,8 +964,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000002977>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -975,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,30 +1033,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_11851_2-ISOPROPYLMALATESYN-RXN>
-] .
+<http://identifiers.org/sgd/S000002977>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN-13163>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003861> ;
@@ -1069,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,16 +1069,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002233_CHEBI_1178_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_11851_2-ISOPROPYLMALATESYN-RXN_SGD_PWY_YeastPathways_LEUSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_11851_2-ISOPROPYLMALATESYN-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1277,7 +1277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1384,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1396,18 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1432,12 +1421,23 @@
           <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002413_RXN-13158_SGD_PWY_YeastPathways_LEUSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_2-ISOPROPYLMALATESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,7 +1569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_LIPASYN-PWY-1.ttl
+++ b/models/YeastPathways_LIPASYN-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,6 +114,9 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_18348>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_17815_PHOSPHOLIPASE-C-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -123,11 +126,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26337> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_18348_3.1.4.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18348> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -139,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -293,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -321,9 +341,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -331,11 +348,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_18348_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +360,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN>
+          <http://model.geneontology.org/CHEBI_18348_3.1.4.11-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_295975_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
@@ -351,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -513,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -660,28 +677,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,23 +752,12 @@
           <http://model.geneontology.org/YKR031C-MONOMER_PHOSCHOL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002234_CHEBI_17815_PHOSPHOLIPASE-C-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,12 +845,23 @@
           <http://model.geneontology.org/YPL268W-MONOMER_3.1.4.11-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_18348_3.1.4.11-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002411_PHOSCHOL-RXN_SGD_PWY_YeastPathways_LIPASYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +907,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/c82fbfbb-620d-485c-8773-0672e0f6c922_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_18348_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -990,7 +990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipids degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1077,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1126,7 +1126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1212,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1264,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_LYSDEGII-PWY.ttl
+++ b/models/YeastPathways_LYSDEGII-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -723,7 +723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1002,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1078,7 +1078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1145,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1226,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1335,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1357,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1533,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1603,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1730,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1746,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1759,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1797,7 +1797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1816,7 +1816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1855,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1866,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,7 +1894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1925,7 +1925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1944,7 +1944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,7 +2016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2051,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2066,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2091,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2115,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,7 +2181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_LYSINE-AMINOAD-PWY-2.ttl
+++ b/models/YeastPathways_LYSINE-AMINOAD-PWY-2.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,23 +100,23 @@
           <http://model.geneontology.org/RXN-7970>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002233_CHEBI_15377_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-127_BFO_0000050_YeastPathways_LYSINE-AMINOAD-PWY-2/YeastPathways_LYSINE-AMINOAD-PWY-2_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,23 +1143,15 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_58349_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_16810>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_2-AMINOADIPATE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1170,11 +1162,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16810>
+<http://purl.obolibrary.org/obo/CHEBI_58672>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1185,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,8 +1188,16 @@
           <http://model.geneontology.org/CHEBI_16810_1.5.1.7-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_58672>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002234_CHEBI_58349_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1207,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1226,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1299,7 +1299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,7 +1318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1375,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1386,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1427,13 +1427,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2BiochemicalReaction73470> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002413_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1443,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,17 +1465,6 @@
           <http://model.geneontology.org/reaction_1.5.1.7-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_RO_0002413_RXN-7970_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
@@ -1473,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1533,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1544,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,7 +1598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,7 +1620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1656,7 +1656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1686,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,7 +1752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1770,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,7 +1786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1902,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1918,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1942,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2059,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2091,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2149,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2230,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2280,7 +2280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2332,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2348,7 +2348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,7 +2364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2378,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2392,7 +2392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2411,7 +2411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2478,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2491,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2505,7 +2505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2525,24 +2525,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000066_reaction_RXN3O-9808_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR115C-MONOMER_RXN3O-9808_controller>
         a       <http://identifiers.org/sgd/S000000319> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2551,13 +2540,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2Protein73565> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_BFO_0000066_reaction_RXN3O-9808_location_lociGO_0005829_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32551_1.5.1.7-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32551> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2568,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2585,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2602,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2617,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,7 +2633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2644,15 +2644,6 @@
           <http://model.geneontology.org/CHEBI_15377_1.5.1.7-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RXN3O-1983_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
@@ -2661,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,12 +2663,21 @@
           <http://model.geneontology.org/MONOMER3O-363_RXN3O-127_controller>
 ] .
 
+<http://model.geneontology.org/reaction_RXN3O-1983_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002234_CHEBI_57287_HOMOCITRATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2695,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2711,7 +2711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2738,7 +2738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2751,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2774,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2791,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2804,7 +2804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2851,7 +2851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2870,7 +2870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2889,7 +2889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,7 +2905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2916,7 +2916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2931,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2947,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2962,7 +2962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2975,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2987,7 +2987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3006,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3020,7 +3020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3039,7 +3039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3081,7 +3081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3092,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3107,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3120,7 +3120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3135,7 +3135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3148,7 +3148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3163,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3174,6 +3174,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58884>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002413_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
@@ -3182,7 +3193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3193,17 +3204,6 @@
           <http://model.geneontology.org/CHEBI_15378_1.5.1.7-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002413_RXN3O-127_SGD_PWY_YeastPathways_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN3O-9808>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3213,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3229,7 +3229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3245,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3259,7 +3259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,7 +3275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3297,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3314,7 +3314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3330,7 +3330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_NADSYN-PWY.ttl
+++ b/models/YeastPathways_NADSYN-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,28 +143,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYSmallMolecule23167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_ARYLFORMAMIDASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD <i>de novo</i> biosynthesis II (from tryptophan) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -625,6 +625,25 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/1.13.11.6-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
+] .
 
 <http://model.geneontology.org/1.13.11.6-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000334> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -645,32 +664,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NADSYN-PWYBiochemicalReaction23341> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002234_CHEBI_994_1.13.11.6-RXN_SGD_PWY_YeastPathways_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/1.13.11.6-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_994_1.13.11.6-RXN>
-] .
 
 <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004502> ;
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -758,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -990,18 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,6 +1015,17 @@
           <http://model.geneontology.org/YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_BFO_0000066_reaction_RXN-5721_location_lociGO_0005829_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004061>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1184,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1480,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1562,7 +1562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1616,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1631,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1647,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1729,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1834,21 +1834,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_57912_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1863,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,27 +1879,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1901,7 +1893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1917,29 +1909,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_30616_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY>
+] .
 
 <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1953,7 +1953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2060,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2077,7 +2077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2096,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2134,7 +2134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2172,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2268,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2282,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2328,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,7 +2380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2433,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,17 +2450,6 @@
 <http://identifiers.org/sgd/S000003596>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2470,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2478,12 +2467,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_BFO_0000050_YeastPathways_NADSYN-PWY/YeastPathways_NADSYN-PWY_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-8665_RO_0002233_CHEBI_15379_RXN-8665_SGD_PWY_YeastPathways_NADSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2494,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2505,7 +2505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2519,7 +2519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2556,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2572,7 +2572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2611,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2627,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2675,7 +2675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2688,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2699,7 +2699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2710,7 +2710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2724,7 +2724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2741,7 +2741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2771,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,7 +2788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2804,7 +2804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2820,7 +2820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2834,7 +2834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2850,7 +2850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2862,7 +2862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2896,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,7 +2912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,7 +2946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2964,7 +2964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +2980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3024,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3040,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3051,7 +3051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3082,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3095,7 +3095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3126,7 +3126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3145,7 +3145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3161,7 +3161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3175,7 +3175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3194,7 +3194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3224,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3239,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3250,17 +3250,6 @@
 <http://purl.obolibrary.org/obo/GO_0004515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:NADSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3269,7 +3258,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NADSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_NADSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3284,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,7 +3309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3328,7 +3328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3347,7 +3347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3363,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3378,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3391,7 +3391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3405,7 +3405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3421,7 +3421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3439,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3455,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3467,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3484,7 +3484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3503,7 +3503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3522,7 +3522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3538,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3552,7 +3552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3568,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3579,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3592,7 +3592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3605,7 +3605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3619,7 +3619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3637,7 +3637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3653,7 +3653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3688,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3702,7 +3702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3718,7 +3718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3739,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3752,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3763,7 +3763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3774,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3785,7 +3785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3800,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3813,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3836,7 +3836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_NONOXIPENT-PWY.ttl
+++ b/models/YeastPathways_NONOXIPENT-PWY.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,26 +468,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002233_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_RIB5PISOM-RXN_RO_0002234_CHEBI_78346_RIB5PISOM-RXN_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -501,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,7 +1020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1140,7 +1140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1176,7 +1176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1220,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (non-oxidative branch) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,7 +1548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1579,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1640,24 +1640,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NONOXIPENT-PWYSmallMolecule34325> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1667,7 +1656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,3 +1666,14 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YPR074C-MONOMER_2TRANSKETO-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_OXIDATIVEPENT-PWY.ttl
+++ b/models/YeastPathways_OXIDATIVEPENT-PWY.ttl
@@ -12,7 +12,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -758,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (oxidative branch) I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -834,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,7 +853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_P4-PWY-1.ttl
+++ b/models/YeastPathways_P4-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -203,29 +203,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_537519>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,9 +363,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/822630ca-7dd6-4bc8-b150-123454e7c8dd_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/3d6e7284-3193-46bc-9b56-53d805300305_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -390,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -449,11 +432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_822630ca-7dd6-4bc8-b150-123454e7c8dd_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +444,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22>
+          <http://model.geneontology.org/822630ca-7dd6-4bc8-b150-123454e7c8dd_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -472,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -726,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -783,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -917,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -948,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,11 +1170,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule23872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/3d6e7284-3193-46bc-9b56-53d805300305_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1206,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,6 +1330,17 @@
           <http://model.geneontology.org/CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_822630ca-7dd6-4bc8-b150-123454e7c8dd_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
@@ -1338,7 +1349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1382,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1396,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1499,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1548,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1615,7 +1626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1640,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1753,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1767,7 +1778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1786,7 +1797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1800,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1839,7 +1850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1864,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1900,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,7 +1927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine and methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1989,7 +2000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2012,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2025,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2043,7 +2054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2056,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2067,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,11 +2105,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_3d6e7284-3193-46bc-9b56-53d805300305_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,7 +2117,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22>
+          <http://model.geneontology.org/3d6e7284-3193-46bc-9b56-53d805300305_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2117,7 +2128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2152,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2167,7 +2178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,7 +2191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2191,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2269,7 +2280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2283,7 +2294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,7 +2314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2316,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2336,7 +2347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2355,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2374,7 +2385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2390,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2404,7 +2415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,7 +2431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2434,7 +2445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2464,7 +2475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2480,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2491,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2509,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2525,7 +2536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,7 +2552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2555,7 +2566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,18 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_74e09ff5-88fe-4096-a3c2-b9ae3bad37be_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2600,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2613,7 +2613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2627,7 +2627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2641,7 +2641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2671,7 +2671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2689,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2702,7 +2702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2730,7 +2730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2753,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2769,7 +2769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2788,7 +2788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2799,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2813,7 +2813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2832,7 +2832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2849,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2869,7 +2869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2888,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2918,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2929,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2944,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2960,18 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2985,7 +2974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3026,7 +3015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3042,7 +3031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3060,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3077,7 +3066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3093,7 +3082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,7 +3101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3128,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3139,7 +3128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3150,7 +3139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3164,7 +3153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3180,7 +3169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3194,7 +3183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,7 +3211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3238,7 +3227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3254,7 +3243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3281,7 +3270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,7 +3289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3316,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3330,7 +3319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3339,29 +3328,12 @@
 <http://purl.obolibrary.org/obo/GO_0004413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1b4034f8-6df3-446f-bda0-2f80e2c17c1e_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3376,7 +3348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3392,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3406,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3417,7 +3389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3430,7 +3402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3449,7 +3421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3465,7 +3437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3497,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3510,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3526,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3542,7 +3514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3572,7 +3544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3589,7 +3561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3605,7 +3577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3627,7 +3599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3643,7 +3615,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_3d6e7284-3193-46bc-9b56-53d805300305_RXN3O-22_SGD_PWY_YeastPathways_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3655,7 +3638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3671,7 +3654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3683,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3697,7 +3680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3717,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3737,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3752,7 +3735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3768,7 +3751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3787,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3801,7 +3784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3816,7 +3799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3832,7 +3815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3852,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3871,7 +3854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3887,7 +3870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3898,7 +3881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3923,7 +3906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3942,7 +3925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3961,7 +3944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3980,7 +3963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,7 +3982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,7 +4005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4041,7 +4024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4061,7 +4044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4080,7 +4063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4099,7 +4082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4115,7 +4098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4124,12 +4107,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/822630ca-7dd6-4bc8-b150-123454e7c8dd_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_P4-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PANTOSYN2-PWY.ttl
+++ b/models/YeastPathways_PANTOSYN2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,11 +132,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_9810cec2-89d9-4761-b274-aa2775c90a4e_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/9810cec2-89d9-4761-b274-aa2775c90a4e_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_BFO_0000050_YeastPathways_PANTOSYN2-PWY/YeastPathways_PANTOSYN2-PWY_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,9 +303,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_20502_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/9810cec2-89d9-4761-b274-aa2775c90a4e_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,6 +323,23 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/CHEBI_20502_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000380>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -335,7 +352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -818,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,29 +895,12 @@
           <http://model.geneontology.org/CHEBI_16526_P-PANTOCYSDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -928,7 +928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1080,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1199,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,23 +1210,6 @@
           <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" , "Provides Input For Rule. The relation '&beta;-alanine + (R)-pantoate + ATP &rarr; (<i>R</i>)-pantothenate + AMP + diphosphate + H<SUP>+</SUP>' 'null' '(<i>R</i>)-pantothenate + ATP &rarr; (<i>R</i>)-4'-phosphopantothenate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -1235,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,6 +1229,17 @@
           <http://model.geneontology.org/PANTOTHENATE-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_9810cec2-89d9-4761-b274-aa2775c90a4e_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_DEPHOSPHOCOAKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1255,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1283,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1296,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1310,7 +1304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1406,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1416,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_20502_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1440,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1459,7 +1464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1498,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1517,7 +1522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1569,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1643,7 +1648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1673,7 +1678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,7 +1769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1800,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,7 +1824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1835,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1846,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1874,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1888,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1900,7 +1905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1919,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1930,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1974,7 +1979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2011,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pantothenate and coenzyme A biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2055,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2066,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2077,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2091,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2130,7 +2135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,7 +2154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,7 +2174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2191,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2220,24 +2225,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25069> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_ec74ad10-5a6b-432f-be3a-0cda61bbd086_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_PANTOATE-BETA-ALANINE-LIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2248,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2265,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2278,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2308,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2322,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2360,7 +2354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2393,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2407,7 +2401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2425,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2461,7 +2455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,18 +2471,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PANTOATE-BETA-ALANINE-LIG-RXN_RO_0002234_CHEBI_456215_PANTOATE-BETA-ALANINE-LIG-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2502,7 +2499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2532,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2545,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2564,7 +2561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2584,7 +2581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2597,7 +2594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2611,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,13 +2651,13 @@
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57945_3-PROPANAL-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_57966_3-PROPANAL-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> , <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> ;
+                <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> , <http://model.geneontology.org/YMR169C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/PANTOATE-BETA-ALANINE-LIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2673,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2685,7 +2682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,7 +2701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,7 +2717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2734,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2749,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2765,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2778,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2805,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2822,7 +2819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2838,7 +2835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2854,7 +2851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2865,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2876,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2890,7 +2887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2909,7 +2906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2926,7 +2923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2946,7 +2943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2963,7 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2976,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2990,7 +2987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3006,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3021,7 +3018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3029,23 +3026,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-474_P-PANTOCYSDECARB-RXN_controller_SGD_PWY_YeastPathways_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3055,11 +3041,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_CHEBI_20502_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PWY_YeastPathways_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3067,7 +3053,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5e6cc8cd-69ce-48ff-b1b9-ff6d4b56bfd6_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/CHEBI_20502_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -3082,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3101,7 +3087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3120,7 +3106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3134,7 +3120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3154,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3167,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3184,7 +3170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3214,7 +3200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3230,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3244,7 +3230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3263,7 +3249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3279,7 +3265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3293,7 +3279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3312,7 +3298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3332,7 +3318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3345,7 +3331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3356,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3370,7 +3356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3390,7 +3376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3409,7 +3395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3428,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3444,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3459,7 +3445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3476,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3489,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3500,7 +3486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3513,7 +3499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3529,7 +3515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3539,6 +3525,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_DEPHOSPHOCOAKIN-RXN>
 ] .
+
+<http://model.geneontology.org/9810cec2-89d9-4761-b274-aa2775c90a4e_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3554,7 +3557,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_RXN-9015> , <http://model.geneontology.org/CHEBI_15379_RXN-9015> , <http://model.geneontology.org/CHEBI_45725_RXN-9015> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16240_RXN-9015> , <http://model.geneontology.org/CHEBI_18090_RXN-9015> , <http://model.geneontology.org/CHEBI_57834_RXN-9015> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-9015> , <http://model.geneontology.org/CHEBI_57834_RXN-9015> , <http://model.geneontology.org/CHEBI_18090_RXN-9015> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR020W-MONOMER_RXN-9015_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3562,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3579,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3592,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3607,7 +3610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3626,7 +3629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3642,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3656,7 +3659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3690,7 +3693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3705,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3721,7 +3724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3737,7 +3740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3748,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3759,7 +3762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3776,7 +3779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3801,7 +3804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3820,7 +3823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3839,7 +3842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3855,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3869,7 +3872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,7 +3895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,7 +3911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3924,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3938,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3953,7 +3956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3975,7 +3978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3991,7 +3994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4005,7 +4008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4021,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4032,7 +4035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4043,7 +4046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4055,7 +4058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4075,7 +4078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4091,7 +4094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4111,7 +4114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4124,7 +4127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4139,7 +4142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4152,7 +4155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4164,7 +4167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4180,7 +4183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4195,7 +4198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4212,7 +4215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4228,7 +4231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4247,7 +4250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4263,7 +4266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4274,7 +4277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4285,7 +4288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4296,7 +4299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4310,7 +4313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4324,7 +4327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4340,7 +4343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4357,7 +4360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4376,7 +4379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4394,7 +4397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4421,7 +4424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4437,7 +4440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4446,7 +4449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PENTOSE-P-PWY.ttl
+++ b/models/YeastPathways_PENTOSE-P-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -718,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -960,13 +960,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYSmallMolecule34927> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_RIB5PISOM-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57634_TRANSALDOL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57634> ;
@@ -977,22 +986,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PENTOSE-P-PWYSmallMolecule35145> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_RIB5PISOM-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJL121C-MONOMER_RIBULP3EPIM-RXN_controller>
         a       <http://identifiers.org/sgd/S000003657> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1025,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1047,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,7 +1081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,7 +1119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1206,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1250,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1281,7 +1281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1482,7 +1482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1509,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1523,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1561,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1628,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1644,7 +1644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1677,7 +1677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,7 +1699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1726,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1743,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,7 +1800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1822,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1836,7 +1836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1852,7 +1852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1866,7 +1866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1896,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,7 +1915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1930,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2003,7 +2003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2022,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2073,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2117,7 +2117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,7 +2136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2174,7 +2174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2190,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2211,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2227,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2263,7 +2263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2282,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,7 +2298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2328,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2341,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2355,7 +2355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,7 +2377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2393,7 +2393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2435,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2474,7 +2474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2497,7 +2497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2513,7 +2513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2532,7 +2532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2562,7 +2562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2583,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2599,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2629,7 +2629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2645,7 +2645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2657,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,7 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2690,7 +2690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2720,7 +2720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2757,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2773,7 +2773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2789,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2804,7 +2804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2817,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2828,7 +2828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2843,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PERIPLASMA-NAD-DEGRADATION.ttl
+++ b/models/YeastPathways_PERIPLASMA-NAD-DEGRADATION.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "periplasmic NAD degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PHOS-PWY.ttl
+++ b/models/YeastPathways_PHOS-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -13,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002234_CHEBI_58779_2.7.7.15-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
@@ -33,18 +33,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -55,13 +46,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYProtein38954> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,23 +99,12 @@
           <http://model.geneontology.org/CHEBI_60377_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_57876_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -136,11 +125,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +137,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
@@ -160,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,11 +283,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,7 +295,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -320,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,6 +320,17 @@
           <http://model.geneontology.org/CHEBI_456216_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,25 +365,6 @@
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
@@ -397,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,23 +389,31 @@
           <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
+] .
 
 <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_15378_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -459,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,9 +475,6 @@
           <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003402> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -496,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,17 +522,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -558,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -567,22 +553,16 @@
 <http://purl.obolibrary.org/obo/GO_0004306>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN4FS-2>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -593,7 +573,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -601,24 +581,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYBiochemicalReaction38600> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -628,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -665,11 +634,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +646,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -688,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,11 +879,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -922,18 +891,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,13 +910,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_295975>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003402>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_37393>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN>
@@ -959,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1025,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1112,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,17 +1111,6 @@
           <http://model.geneontology.org/CHEBI_58190_ETHANOLAMINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1159,13 +1120,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38935> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004608>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1174,11 +1157,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1169,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
@@ -1194,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1281,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1311,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1324,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1333,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1360,7 +1343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1373,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1383,11 +1366,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1378,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1406,7 +1389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,15 +1414,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/PHOSPHASERSYN-RXN> , <http://model.geneontology.org/2.7.8.11-RXN> , <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,11 +1434,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,7 +1446,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1474,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1508,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1529,32 +1512,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1528,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
@@ -1574,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1605,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1635,11 +1601,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1613,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN4FS-2>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1658,7 +1624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1674,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1688,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1718,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,17 +1697,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1757,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1793,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1832,6 +1798,17 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1843,7 +1820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1874,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,12 +1859,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_15378_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1902,7 +1890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,7 +1925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,18 +1961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1998,7 +1975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2028,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2078,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2092,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,9 +2119,6 @@
           <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
@@ -2153,7 +2127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2172,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2182,11 +2156,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,7 +2168,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2205,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2277,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2290,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2301,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2327,7 +2301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,6 +2311,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_ETHANOLAMINE-KINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002413_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/2.1.1.17-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004608> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2349,15 +2334,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/2.1.1.71-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2373,7 +2358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2398,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2413,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2432,7 +2417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2458,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2471,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2485,7 +2470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2501,18 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_9f437cfa-4e93-465b-96a8-7487ce6f1c65_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2524,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2543,7 +2517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2562,7 +2536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2573,7 +2547,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2600,11 +2585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,7 +2597,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2623,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,12 +2619,23 @@
           <http://model.geneontology.org/YNL130C-MONOMER_RXN-5781_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_37563_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2653,7 +2649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,7 +2668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidic acid and phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2708,7 +2704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,7 +2723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2743,7 +2739,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2754,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2770,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2785,11 +2792,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2797,7 +2804,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_59789_RXN4FS-2>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
@@ -2805,18 +2812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +2826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2846,7 +2842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2860,7 +2856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,7 +2872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2887,7 +2883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2937,7 +2933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,17 +2944,6 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2967,7 +2952,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2978,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2989,7 +2985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3004,7 +3000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3012,8 +3008,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/CHEBI_17152>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001165> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3022,7 +3018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3039,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3066,7 +3062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3083,28 +3079,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39151> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3116,7 +3095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3138,7 +3117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3154,18 +3133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3174,7 +3142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3188,7 +3156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,7 +3176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3225,7 +3193,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3233,7 +3201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3249,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3260,6 +3228,17 @@
           <http://model.geneontology.org/CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005074>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3268,7 +3247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3285,7 +3264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3294,6 +3273,25 @@
           <http://model.geneontology.org/CHOLINE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.8.11-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
@@ -3305,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3313,27 +3311,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002234_CHEBI_60377_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.8.11-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN>
-] .
-
 <http://identifiers.org/sgd/S000003434>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58779>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3343,29 +3333,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17962> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_16110_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3379,7 +3375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3398,7 +3394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3409,6 +3405,9 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15958>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002554> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3416,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3429,7 +3428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3457,7 +3456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3472,17 +3471,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3498,7 +3497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3528,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3545,7 +3544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3561,7 +3560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3577,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3588,7 +3587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3602,7 +3601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3618,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3630,9 +3629,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
@@ -3641,7 +3637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3660,18 +3656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3685,7 +3670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,7 +3690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3721,7 +3706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3744,7 +3729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3757,7 +3742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3768,7 +3753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3776,17 +3761,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Provides Input For Rule. The relation 'CTP + a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP> &rarr; a CDP-diacylglycerol + diphosphate' 'null' 'a CDP-diacylglycerol + <i>sn</i>-glycerol 3-phosphate &rarr; CMP + 1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3805,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3818,7 +3803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3826,17 +3811,6 @@
 
 <http://identifiers.org/sgd/S000002301>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -3847,7 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3863,7 +3837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3874,33 +3848,16 @@
           <http://model.geneontology.org/2.7.7.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17815_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3911,7 +3868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3923,11 +3880,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3935,7 +3892,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_15377_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
@@ -3943,7 +3900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3957,7 +3914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,7 +3933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3990,7 +3947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4003,17 +3960,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4029,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4042,7 +3999,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4059,7 +4027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4070,17 +4038,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN4FS-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
@@ -4089,7 +4046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4109,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4125,7 +4082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4150,7 +4107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4169,7 +4126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4189,7 +4146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4212,7 +4169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4225,7 +4182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4239,7 +4196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4250,15 +4207,12 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/db3f79e0-ee31-40a6-8eb6-bd1ce3ccda11_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002413_RXN-5781_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4278,7 +4232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4289,9 +4243,6 @@
           <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
         a       <http://identifiers.org/sgd/S000003389> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4299,7 +4250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4315,7 +4266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4331,7 +4282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4345,7 +4296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4365,7 +4316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4378,7 +4329,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4392,7 +4365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4403,28 +4376,6 @@
           <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002233_CHEBI_29089_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
@@ -4433,7 +4384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4463,7 +4414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4481,24 +4432,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYProtein38990> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_855056bd-56d4-4740-8849-1d39080f4cae_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -4511,7 +4451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4527,7 +4467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4538,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4555,7 +4495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4574,7 +4514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4594,7 +4534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4607,7 +4547,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4617,11 +4568,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.71-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002333_YJR073C-MONOMER_RXN3O-349_controller_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4632,45 +4602,29 @@
           <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.71-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15958> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4681,7 +4635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4689,6 +4643,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_16749>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4699,24 +4664,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
         a       <http://identifiers.org/sgd/S000003834> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4725,7 +4679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4741,7 +4695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4761,7 +4715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4774,7 +4728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4786,7 +4740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4805,22 +4759,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17962>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000000233>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4830,7 +4776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4839,7 +4785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4853,7 +4799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4864,6 +4810,17 @@
           <http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0003882>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4872,7 +4829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4885,7 +4842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4901,7 +4858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4917,7 +4874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4928,7 +4885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4943,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4962,7 +4919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4981,7 +4938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4997,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5005,17 +4962,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Provides Input For Rule. The relation 'CTP + a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP> &rarr; a CDP-diacylglycerol + diphosphate' 'null' 'a CDP-diacylglycerol + L-serine &harr; CMP + a 3-<i>O</i>-<i>sn</i>-phosphatidyl-L-serine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -5030,7 +4987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5055,7 +5012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5066,15 +5023,12 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/c58c0a4a-fd04-406b-a31e-c78261278a3c_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5084,11 +5038,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5096,7 +5050,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5107,7 +5061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5123,7 +5077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5134,7 +5088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5145,7 +5099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5159,7 +5113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5178,7 +5132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5198,7 +5152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5218,7 +5172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5234,7 +5188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5254,7 +5208,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5262,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5275,7 +5229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5284,7 +5238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5295,7 +5249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5311,7 +5265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5322,6 +5276,17 @@
 <http://identifiers.org/sgd/S000003834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5331,7 +5296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5347,7 +5312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5363,7 +5328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5372,7 +5337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5386,7 +5351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5400,7 +5365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5416,7 +5381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5427,7 +5392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5439,7 +5404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5455,7 +5420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5469,7 +5434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5483,7 +5448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5497,7 +5462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5516,7 +5481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5532,22 +5497,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7895a567-25c8-4789-9b65-abc0b04cb4a7_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37393> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5557,7 +5528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5576,7 +5547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5596,17 +5567,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/0baab9b6-969a-4e1b-9dc0-0bf1604eeeea_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN4FS-2> , <http://model.geneontology.org/RXN3O-349> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN3O-349> , <http://model.geneontology.org/RXN4FS-2> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5622,7 +5593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5633,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5648,7 +5619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5665,7 +5636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5681,7 +5652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5692,33 +5663,27 @@
           <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39044> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5728,7 +5693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5739,6 +5704,23 @@
           <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39044> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5747,7 +5729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5758,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5773,7 +5755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5786,7 +5768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5795,7 +5777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5805,11 +5787,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5817,7 +5799,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/23f2c9fc-ef77-41ef-88d4-28dc715b3e9a_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5828,7 +5810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5839,23 +5821,12 @@
           <http://model.geneontology.org/YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PHOS-PWY/YeastPathways_PHOS-PWY_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5870,7 +5841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5886,7 +5857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5902,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5913,7 +5884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5922,7 +5893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5936,7 +5907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5956,7 +5927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5969,7 +5940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5984,7 +5955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5998,23 +5969,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6025,7 +5985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6041,7 +6001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6060,7 +6020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6076,7 +6036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6091,7 +6051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6102,17 +6062,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
@@ -6121,7 +6070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6140,7 +6089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6156,36 +6105,42 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_6a7f0829-0282-4e0c-aa50-9905dd719dc0_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOS-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" , "Provides Input For Rule. The relation 'CTP + a 1,2-diacyl-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP> &rarr; a CDP-diacylglycerol + diphosphate' 'null' 'a CDP-diacylglycerol + <I>myo</I>-inositol &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + CMP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002411_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_2.7.8.11-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -6200,7 +6155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6220,7 +6175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6233,7 +6188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6248,7 +6203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6264,7 +6219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6280,21 +6235,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/87efaba4-5053-4dee-9885-cdf36515cc3a_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6308,7 +6260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6328,7 +6280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6340,11 +6292,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6352,8 +6304,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/05d1f440-1f08-4aac-9f22-efe7f6108711_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004307> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6374,7 +6337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6387,7 +6350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6412,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6428,7 +6391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6447,7 +6410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6462,11 +6425,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6474,7 +6437,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PHOS-PWY>
@@ -6482,7 +6445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6493,23 +6456,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+          "Provides Input For Rule. The relation 'a CDP-diacylglycerol + <i>sn</i>-glycerol 3-phosphate &rarr; CMP + 1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP>' 'null' '1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; an L-1-phosphatidyl-<i>sn</i>-glycerol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002413_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -6525,7 +6488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6544,7 +6507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6564,7 +6527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6580,7 +6543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6600,7 +6563,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5ba5f8c6-84e0-4951-b60e-c310d4348ad3_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6608,7 +6571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6625,7 +6588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6636,12 +6599,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6655,7 +6629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6666,12 +6640,23 @@
           <http://model.geneontology.org/CHEBI_37563_2.7.7.14-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002333_YJR073C-MONOMER_RXN4FS-2_controller_SGD_PWY_YeastPathways_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6682,7 +6667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PHOSLIPSYN2-PWY-1.ttl
+++ b/models/YeastPathways_PHOSLIPSYN2-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,23 +53,6 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
@@ -78,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -110,11 +93,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,18 +105,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +124,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_2.1.1.17-RXN_location_lociGO_0005829>
@@ -149,18 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -172,7 +144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,27 +186,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
@@ -246,17 +204,19 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17962_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/PHOSPHASERSYN-RXN> , <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +224,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_BFO_0000066_reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
@@ -272,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -282,11 +242,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +254,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN>
@@ -306,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -351,11 +311,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +323,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CARDIOLIPSYN-RXN>
@@ -383,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -436,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,18 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,11 +527,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,11 +539,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -605,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,15 +588,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +630,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -685,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,17 +669,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -733,11 +690,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +702,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -756,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,6 +727,17 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002413_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
@@ -778,7 +746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,6 +760,23 @@
 <http://identifiers.org/sgd/S000005113>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_17962_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17962> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_11750>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -800,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,15 +838,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_PHOSPHASERDECARB-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/2.1.1.71-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,51 +909,14 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002301> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "cardiolipin synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27109> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_62237> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -979,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,11 +940,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002301> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "cardiolipin synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27109> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1007,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1044,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1019,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
@@ -1064,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1078,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,12 +1052,29 @@
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15958> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1104,11 +1084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1096,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
@@ -1124,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1143,23 +1123,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1170,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1206,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,23 +1205,12 @@
           <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1270,7 +1222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1354,11 +1306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1318,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1377,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,6 +1340,17 @@
           <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1397,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,18 +1398,15 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,30 +1414,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1487,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,12 +1439,23 @@
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002233_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1514,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1522,21 +1474,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Provides Input For Rule. The relation 'a CDP-diacylglycerol + <i>sn</i>-glycerol 3-phosphate &rarr; CMP + 1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP>' 'null' '1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; an L-1-phosphatidyl-<i>sn</i>-glycerol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002413_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/PGPPHOSPHA-RXN>
 ] .
 
 <http://model.geneontology.org/YER026C-MONOMER_PHOSPHASERSYN-RXN_controller>
@@ -1546,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1559,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1573,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,7 +1541,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,11 +1622,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,7 +1634,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
@@ -1681,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1694,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1722,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1700,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1745,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1758,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1769,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1805,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,20 +1812,20 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/b0dbe14b-637c-4bd4-9432-e430a0fc387e_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17962> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+                "a CDP-diacylglycerol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1871,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1883,7 +1846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1894,6 +1857,17 @@
           <http://model.geneontology.org/CHEBI_16110_RXN3O-349>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
@@ -1902,7 +1876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,11 +1912,25 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37393> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_60377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1959,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1972,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2001,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2013,11 +2001,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2013,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
@@ -2037,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2053,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2083,12 +2071,23 @@
           <http://model.geneontology.org/CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2112,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2126,16 +2125,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_62237>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_17754>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2145,7 +2136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,8 +2147,16 @@
           <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17754>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2167,7 +2166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,17 +2213,6 @@
           <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_26e24d24-6d1f-4243-b77c-09dfe5a89088_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
@@ -2233,7 +2221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2244,17 +2232,6 @@
           <http://model.geneontology.org/YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2264,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2277,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2288,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2302,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2317,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2336,7 +2313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2356,13 +2333,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27168> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_37393>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2372,7 +2352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2383,17 +2363,6 @@
           <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_f9e09d37-9e64-48b5-938a-7c3a93d5007a_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
@@ -2402,7 +2371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2423,7 +2392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2431,22 +2400,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17962>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2461,7 +2452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2472,18 +2463,15 @@
           <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16038>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2491,7 +2479,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000066_reaction_RXN3O-349_location_lociGO_0005829_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
@@ -2499,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2508,33 +2496,22 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/26cab190-e758-474e-91c7-bd9885256a84_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_16038>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17152>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2549,7 +2526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2580,17 +2557,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/0338491a-0751-4df1-af2a-9a82dc81c304_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/44bb8907-c764-417f-a5d0-512c08529040_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-349> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2609,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2625,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2635,11 +2612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2647,7 +2624,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
@@ -2655,7 +2632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2670,7 +2647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2686,7 +2663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2705,7 +2682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2720,7 +2697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2736,7 +2713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2773,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2786,26 +2763,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/244a7d90-5299-4da9-8a03-415a5ecfd2c4_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2815,7 +2775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2834,7 +2794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2856,7 +2816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2867,12 +2827,23 @@
           <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_YeastPathways_PHOSLIPSYN2-PWY-1/YeastPathways_PHOSLIPSYN2-PWY-1_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2883,18 +2854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2905,7 +2865,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2922,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2932,11 +2903,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2944,7 +2915,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2955,7 +2926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2971,7 +2942,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2986,7 +2968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2998,11 +2980,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +2992,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PHOSLIPSYN2-PWY-1>
@@ -3018,11 +3000,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15958>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008962> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3033,7 +3018,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1ee9f9ad-dcac-4035-8820-802e4fb4d563_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3041,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3054,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3067,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,10 +3079,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1BiochemicalReaction27264> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_PLPSAL-PWY.ttl
+++ b/models/YeastPathways_PLPSAL-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -352,7 +352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyridoxal 5'-phosphate salvage I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1077,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1207,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1237,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1328,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1579,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1618,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1648,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1673,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1684,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +1695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,7 +1725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +1739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1767,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1792,7 +1792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1968,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2056,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2099,7 +2099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2151,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_POLYAMSYN-YEAST-PWY.ttl
+++ b/models/YeastPathways_POLYAMSYN-YEAST-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -61,24 +61,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27547> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -88,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,6 +87,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57834_SPERMIDINESYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_15378_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000005412>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -333,6 +333,17 @@
 <http://purl.obolibrary.org/obo/GO_0016768>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YOL052C-MONOMER_SAMDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005412> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -340,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,17 +389,6 @@
           <http://model.geneontology.org/CHEBI_57443_SAMDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_17509_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17509> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of polyamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -788,7 +788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,6 +799,17 @@
           <http://model.geneontology.org/CHEBI_326268_ORNDECARBOX-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
@@ -807,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,17 +828,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_45725_SPERMINE-SYNTHASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_YeastPathways_POLYAMSYN-YEAST-PWY/YeastPathways_POLYAMSYN-YEAST-PWY_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1038,26 +1038,26 @@
 <http://identifiers.org/sgd/S000004136>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_SPERMINE-SYNTHASE-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_RO_0002233_CHEBI_57443_SAMDECARB-RXN_SGD_PWY_YeastPathways_POLYAMSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1119,7 +1119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,7 +1408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1450,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1514,7 +1514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,7 +1533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1566,7 +1566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PROSYN-PWY.ttl
+++ b/models/YeastPathways_PROSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,23 +223,23 @@
           <http://model.geneontology.org/CHEBI_15378_PYRROLINECARBREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PYRROLINECARBREDUCT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_58066_GLUTSEMIALDEHYDROG-RXN_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -664,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,7 +979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1410,7 +1410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1511,7 +1511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,18 +1530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PROSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,6 +1554,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17388_SPONTPRO-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PROSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PROUT-PWY.ttl
+++ b/models/YeastPathways_PROUT-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,11 +44,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17594_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903>
+          <http://model.geneontology.org/CHEBI_17594_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -67,7 +67,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -256,15 +256,12 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_RXN-14116_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -279,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,17 +399,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -424,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,21 +441,6 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
@@ -478,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -545,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -571,11 +542,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,8 +554,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903>
+          <http://model.geneontology.org/CHEBI_60039_RXN-14903>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_17594>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -594,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +587,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17594_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -624,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -660,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -719,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,11 +797,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_60039_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_36141_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +809,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60039_RXN-14903>
+          <http://model.geneontology.org/CHEBI_36141_RXN-14903>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
@@ -836,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,6 +867,9 @@
           <http://model.geneontology.org/RXN-14116>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_36141>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -890,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -946,24 +934,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/CHEBI_17594_RXN-14903>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17594> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "an electron-transfer quinol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_36141_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36141> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -978,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +1000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,13 +1020,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29072> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_CHEBI_36141_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-14903>
         a       <http://purl.obolibrary.org/obo/GO_0004657> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1034,9 +1048,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_36141_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b4af2955-7936-4559-8eba-283db538ffd6_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_17594_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1044,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1171,18 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_54ee03ee-deb9-4f8f-87fe-3b07480dfb2b_RXN-14903_SGD_PWY_YeastPathways_PROUT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PRPP-PWY-1.ttl
+++ b/models/YeastPathways_PRPP-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,13 +73,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1Protein40694> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/00eb5a9b-d8ca-4e34-aee6-4ced69e0a8f8_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58457> ;
@@ -90,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -382,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,6 +574,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_161bdf25-9925-431e-b52b-1827e6e5d218_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -567,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -617,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -788,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -906,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -948,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +1014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1125,32 +1153,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1169,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_GART-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001664>
@@ -1175,7 +1186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1313,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1360,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1418,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1432,7 +1443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1509,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1575,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1616,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1631,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1644,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1656,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1686,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1763,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1815,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1850,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1903,7 +1914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1919,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1934,7 +1945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1980,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +2006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2063,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2078,7 +2089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2097,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,7 +2124,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_00eb5a9b-d8ca-4e34-aee6-4ced69e0a8f8_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2135,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2149,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2171,7 +2204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2198,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2228,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2240,7 +2273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2276,7 +2309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2304,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2336,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2347,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2362,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2378,7 +2411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2407,7 +2440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,7 +2456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2453,7 +2486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2473,7 +2506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2490,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2507,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2523,7 +2556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,7 +2572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2550,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2561,7 +2594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2575,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2612,7 +2645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2626,7 +2659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2645,7 +2678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2664,7 +2697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2683,7 +2716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2699,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2714,7 +2747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2730,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2763,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2776,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2806,7 +2839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,7 +2858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2845,7 +2878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2862,7 +2895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2881,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2901,7 +2934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2934,7 +2967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2954,7 +2987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2971,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2986,7 +3019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3002,7 +3035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3020,7 +3053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3036,7 +3069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3055,7 +3088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3070,7 +3103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3085,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3098,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3112,7 +3145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3128,7 +3161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3139,7 +3172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3150,7 +3183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3161,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3172,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3183,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3197,7 +3230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3216,7 +3249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3230,7 +3263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3260,7 +3293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,7 +3313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3293,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3307,7 +3340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,7 +3359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3341,7 +3374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3354,7 +3387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3368,7 +3401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3384,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3412,7 +3445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3432,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3445,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3456,7 +3489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3470,7 +3503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3489,7 +3522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3511,7 +3544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3531,7 +3564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3547,7 +3580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3567,7 +3600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3583,7 +3616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3599,7 +3632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3613,7 +3646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3632,7 +3665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3647,7 +3680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3674,7 +3707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3687,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3696,7 +3729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3710,7 +3743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3726,7 +3759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3737,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3748,7 +3781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3759,7 +3792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3773,7 +3806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3789,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3800,7 +3833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3811,7 +3844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3827,7 +3860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3843,7 +3876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3873,7 +3906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3889,7 +3922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3905,7 +3938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3916,7 +3949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3927,7 +3960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3936,7 +3969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3948,7 +3981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,7 +3997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3976,7 +4009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3996,7 +4029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4012,7 +4045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4028,7 +4061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4042,7 +4075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4058,7 +4091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4072,7 +4105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4094,7 +4127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4114,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4130,7 +4163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4149,7 +4182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4168,7 +4201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4184,7 +4217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4193,7 +4226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4204,7 +4237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4217,11 +4250,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_00eb5a9b-d8ca-4e34-aee6-4ced69e0a8f8_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4229,7 +4262,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN>
+          <http://model.geneontology.org/00eb5a9b-d8ca-4e34-aee6-4ced69e0a8f8_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
@@ -4241,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4258,24 +4291,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40395> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_HISTAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4286,7 +4308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4294,12 +4316,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4313,7 +4346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4332,7 +4365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4346,7 +4379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4362,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4373,7 +4406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4385,7 +4418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4404,7 +4437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4424,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4437,7 +4470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4446,7 +4479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4457,7 +4490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4473,7 +4506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4492,7 +4525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4503,7 +4536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4514,7 +4547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4528,7 +4561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4547,7 +4580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4566,7 +4599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4596,7 +4629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4609,18 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4634,7 +4656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4654,7 +4676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4670,7 +4692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4681,17 +4703,6 @@
           <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4701,7 +4712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4716,7 +4727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4732,7 +4743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4751,7 +4762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4767,7 +4778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4781,7 +4792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4803,7 +4814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4819,7 +4830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4830,7 +4841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4847,7 +4858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4870,7 +4881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of histidine, purine, and pyrimidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4883,7 +4894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4897,7 +4908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4913,7 +4924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4924,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4933,7 +4944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4948,7 +4959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4964,7 +4975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4980,7 +4991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4994,7 +5005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5010,7 +5021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5025,7 +5036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5038,7 +5049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5047,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5058,7 +5069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5075,7 +5086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5091,7 +5102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5102,7 +5113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5117,7 +5128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5130,7 +5141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5144,7 +5155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5164,7 +5175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5177,7 +5188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5188,7 +5199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5207,7 +5218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5223,7 +5234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5237,7 +5248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5253,7 +5264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5267,7 +5278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5283,7 +5294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5298,7 +5309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5317,7 +5328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5336,7 +5347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5352,7 +5363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5361,7 +5372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5375,7 +5386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5395,7 +5406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5408,7 +5419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5422,7 +5433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5441,7 +5452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5460,7 +5471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5476,7 +5487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5487,7 +5498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5498,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5512,7 +5523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5523,7 +5534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5548,7 +5559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5561,7 +5572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5572,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5589,7 +5600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5608,7 +5619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5621,7 +5632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5634,7 +5645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5648,7 +5659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5660,7 +5671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5676,7 +5687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5687,7 +5698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5702,7 +5713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5715,7 +5726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5729,7 +5740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5748,7 +5759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5767,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5778,7 +5789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5792,7 +5803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5811,7 +5822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5827,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5838,7 +5849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5852,7 +5863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5868,7 +5879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5883,7 +5894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5899,7 +5910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5918,7 +5929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5937,7 +5948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5957,7 +5968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5973,7 +5984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5992,7 +6003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6008,7 +6019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6019,7 +6030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6030,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6044,7 +6055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6060,7 +6071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6071,7 +6082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6085,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6094,7 +6105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6111,7 +6122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6127,7 +6138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6138,7 +6149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6147,7 +6158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6158,7 +6169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6169,7 +6180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6178,7 +6189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6192,7 +6203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6203,7 +6214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6214,7 +6225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6226,7 +6237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6251,7 +6262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6267,7 +6278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6281,7 +6292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6300,7 +6311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6316,7 +6327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6331,7 +6342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6344,7 +6355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6355,7 +6366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6369,7 +6380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6399,7 +6410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6415,7 +6426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6435,7 +6446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6451,7 +6462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6467,7 +6478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6481,7 +6492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6500,7 +6511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6519,7 +6530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6539,7 +6550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6556,7 +6567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6572,7 +6583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6590,7 +6601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6606,7 +6617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6639,7 +6650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6652,7 +6663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6664,7 +6675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6683,7 +6694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6703,7 +6714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6720,9 +6731,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/CHEBI_134413_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> , <http://model.geneontology.org/1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/00eb5a9b-d8ca-4e34-aee6-4ced69e0a8f8_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6730,7 +6741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6743,7 +6754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6757,7 +6768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6773,7 +6784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6788,7 +6799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6805,7 +6816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6818,7 +6829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6831,7 +6842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6847,7 +6858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6866,7 +6877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6886,7 +6897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6899,7 +6910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6913,7 +6924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6932,7 +6943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6946,7 +6957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6965,7 +6976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6981,7 +6992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6992,7 +7003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7005,7 +7016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7018,7 +7029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7032,7 +7043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7048,7 +7059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7059,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7074,7 +7085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7090,7 +7101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7106,7 +7117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7119,7 +7130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7135,7 +7146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7154,7 +7165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7173,7 +7184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7192,7 +7203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7212,7 +7223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7225,7 +7236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7236,7 +7247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7250,7 +7261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7272,7 +7283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7288,7 +7299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7299,7 +7310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7310,7 +7321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7328,7 +7339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7341,7 +7352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7355,7 +7366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7385,7 +7396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7398,7 +7409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7413,7 +7424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7429,7 +7440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7440,7 +7451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7454,7 +7465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7465,7 +7476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7476,7 +7487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7494,7 +7505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7510,7 +7521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7528,7 +7539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7544,7 +7555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7557,7 +7568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7570,7 +7581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7595,7 +7606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7611,7 +7622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7627,7 +7638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7638,7 +7649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7663,7 +7674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7676,7 +7687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7693,7 +7704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7711,7 +7722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7719,12 +7730,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9929_RO_0002333_YKL216W-MONOMER_RXN-9929_controller_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7738,7 +7766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7758,7 +7786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7776,7 +7804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7789,7 +7817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7817,7 +7845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7833,7 +7861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7849,7 +7877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7863,7 +7891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7883,7 +7911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7900,7 +7928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7916,7 +7944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7932,7 +7960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7943,7 +7971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7957,7 +7985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7973,7 +8001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7984,7 +8012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7998,7 +8026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8009,23 +8037,6 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
-<http://model.geneontology.org/27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
@@ -8034,7 +8045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8064,7 +8075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8077,7 +8088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8088,7 +8099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8101,7 +8112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8117,7 +8128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8140,7 +8151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8157,7 +8168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8170,7 +8181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8181,7 +8192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8192,7 +8203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8203,7 +8214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8217,7 +8228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8233,7 +8244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8248,7 +8259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8261,7 +8272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8276,7 +8287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8289,7 +8300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8300,7 +8311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8314,7 +8325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8336,7 +8347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8352,7 +8363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8367,7 +8378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8394,7 +8405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8410,7 +8421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8426,7 +8437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8437,7 +8448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8451,7 +8462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8474,7 +8485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8490,7 +8501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8509,7 +8520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8524,7 +8535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8540,7 +8551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8559,7 +8570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8579,7 +8590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8595,7 +8606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8620,7 +8631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8639,7 +8650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8655,7 +8666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8669,7 +8680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8685,7 +8696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8696,7 +8707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8710,7 +8721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8724,7 +8735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8747,7 +8758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8763,7 +8774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8789,7 +8800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8802,7 +8813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8815,7 +8826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8831,7 +8842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8851,7 +8862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8867,7 +8878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8887,7 +8898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8904,7 +8915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8920,7 +8931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8943,7 +8954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8956,7 +8967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8968,7 +8979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8988,7 +8999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9004,7 +9015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9015,7 +9026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9026,7 +9037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9041,7 +9052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9060,7 +9071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9078,7 +9089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9091,7 +9102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9102,7 +9113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9111,7 +9122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9128,7 +9139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9144,7 +9155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9161,7 +9172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9181,7 +9192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9197,7 +9208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9213,7 +9224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9230,7 +9241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9249,7 +9260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9265,7 +9276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9282,7 +9293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9298,7 +9309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9313,7 +9324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9325,11 +9336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9337,7 +9348,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9348,7 +9359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9364,7 +9375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9381,7 +9392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9400,7 +9411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9416,7 +9427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9427,7 +9438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9441,7 +9452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9457,7 +9468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9468,7 +9479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9485,7 +9496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9503,7 +9514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9519,7 +9530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9541,7 +9552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9560,7 +9571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9574,7 +9585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9593,7 +9604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9613,7 +9624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9629,7 +9640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9645,7 +9656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9659,7 +9670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9675,7 +9686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9691,7 +9702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9710,7 +9721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9726,7 +9737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9740,7 +9751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9760,7 +9771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9776,7 +9787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9796,7 +9807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9809,7 +9820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9818,7 +9829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9829,7 +9840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9843,7 +9854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9865,7 +9876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9887,7 +9898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9906,7 +9917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9922,7 +9933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9936,7 +9947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9952,7 +9963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9972,7 +9983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9999,7 +10010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10012,7 +10023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10025,7 +10036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10038,7 +10049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10049,7 +10060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10060,7 +10071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10071,7 +10082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10082,7 +10093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10097,7 +10108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10110,7 +10121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10121,7 +10132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10135,7 +10146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10151,7 +10162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10174,7 +10185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10187,7 +10198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10201,7 +10212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10217,7 +10228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10228,7 +10239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10242,7 +10253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10261,7 +10272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10277,7 +10288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10288,7 +10299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10306,7 +10317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10322,7 +10333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10338,7 +10349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10349,7 +10360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10363,7 +10374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10382,7 +10393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10397,7 +10408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10410,7 +10421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10424,7 +10435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10435,23 +10446,6 @@
           <http://model.geneontology.org/YLR359W-MONOMER_AMPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
@@ -10460,7 +10454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10482,7 +10476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10498,7 +10492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10512,7 +10506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10531,7 +10525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10547,7 +10541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10562,7 +10556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10575,7 +10569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10583,13 +10577,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10605,7 +10599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10616,7 +10610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10630,7 +10624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10648,7 +10642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10664,7 +10658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10680,7 +10674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10691,7 +10685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10705,7 +10699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10723,7 +10717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10740,7 +10734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10756,7 +10750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10772,7 +10766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10784,7 +10778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10800,7 +10794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10811,7 +10805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10822,7 +10816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10847,7 +10841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10874,7 +10868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10887,7 +10881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10901,7 +10895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10917,7 +10911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10928,7 +10922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10943,7 +10937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10962,7 +10956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10978,7 +10972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10989,7 +10983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11002,7 +10996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11018,7 +11012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11038,7 +11032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11058,7 +11052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11077,7 +11071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11096,7 +11090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11112,7 +11106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11126,7 +11120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11146,7 +11140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11162,7 +11156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11182,9 +11176,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/161bdf25-9925-431e-b52b-1827e6e5d218_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -11192,7 +11186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11208,7 +11202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11227,7 +11221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11245,7 +11239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11258,7 +11252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11274,7 +11268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11287,7 +11281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11301,7 +11295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11317,7 +11311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11328,7 +11322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11339,7 +11333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11350,7 +11344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11364,7 +11358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11380,7 +11374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11395,7 +11389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11411,7 +11405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11434,7 +11428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11450,7 +11444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11469,7 +11463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11480,7 +11474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11497,7 +11491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11513,7 +11507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11527,7 +11521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11547,7 +11541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11563,7 +11557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11579,7 +11573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11590,7 +11584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11599,7 +11593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11610,7 +11604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11625,7 +11619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11640,7 +11634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11653,7 +11647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11664,7 +11658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11675,7 +11669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11686,7 +11680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11695,7 +11689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11712,7 +11706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11732,7 +11726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11748,7 +11742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11768,7 +11762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11784,7 +11778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11803,7 +11797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11817,7 +11811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11836,7 +11830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11855,7 +11849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11867,7 +11861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11886,7 +11880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11906,7 +11900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11923,7 +11917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11945,7 +11939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11961,7 +11955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11972,7 +11966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11989,7 +11983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12002,7 +11996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12016,7 +12010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12036,7 +12030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12051,7 +12045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12064,7 +12058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12078,7 +12072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12094,7 +12088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12108,7 +12102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12126,7 +12120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12143,7 +12137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12170,7 +12164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12186,7 +12180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12197,6 +12191,17 @@
           <http://model.geneontology.org/CHEBI_57980_HISTAMINOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
@@ -12205,7 +12210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12221,7 +12226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12232,7 +12237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12246,7 +12251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12265,7 +12270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12281,7 +12286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12295,7 +12300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12311,7 +12316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12322,7 +12327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12337,7 +12342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12353,7 +12358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12368,7 +12373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12387,7 +12392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12405,7 +12410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12421,7 +12426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12435,7 +12440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12465,7 +12470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12492,7 +12497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12505,7 +12510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12520,7 +12525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12539,7 +12544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12565,7 +12570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12584,7 +12589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12603,7 +12608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12623,7 +12628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12639,7 +12644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12659,7 +12664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12679,7 +12684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12692,7 +12697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12706,7 +12711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12720,7 +12725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12740,7 +12745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12753,7 +12758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12769,7 +12774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12785,7 +12790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12801,7 +12806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12812,7 +12817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12827,7 +12832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12843,7 +12848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12862,7 +12867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12884,7 +12889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12903,7 +12908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12918,11 +12923,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12930,7 +12935,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_BFO_0000050_YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1_SGD_PWY_YeastPathways_PRPP-PWY-1>
@@ -12938,7 +12943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12949,7 +12954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12960,7 +12965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12971,7 +12976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12982,7 +12987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12996,7 +13001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13016,7 +13021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13033,7 +13038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13051,7 +13056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13078,7 +13083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13094,7 +13099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13110,7 +13115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13124,7 +13129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13143,7 +13148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13162,7 +13167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13181,7 +13186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13197,7 +13202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13212,7 +13217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13228,7 +13233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13242,7 +13247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13258,7 +13263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13273,7 +13278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13286,7 +13291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13300,7 +13305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13316,7 +13321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13327,7 +13332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13338,7 +13343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13349,7 +13354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13365,7 +13370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13381,7 +13386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13397,7 +13402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13411,7 +13416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13430,7 +13435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13444,7 +13449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13463,7 +13468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13485,7 +13490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13505,7 +13510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13521,7 +13526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13531,23 +13536,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_AIRCARBOXY-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/1c61bc1e-7c10-4e09-9602-c9a9db95844c_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004550> ;
@@ -13566,7 +13554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13582,7 +13570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13601,7 +13589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13621,7 +13609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13637,7 +13625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13653,7 +13641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13664,7 +13652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13675,7 +13663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13689,7 +13677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13708,7 +13696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13728,7 +13716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13744,7 +13732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13755,7 +13743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13767,7 +13755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13783,7 +13771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13798,7 +13786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13814,7 +13802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13830,7 +13818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13841,7 +13829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13852,7 +13840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13867,7 +13855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13883,7 +13871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13899,7 +13887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13910,7 +13898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13921,7 +13909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13936,7 +13924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13949,18 +13937,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_134413_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002233_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13975,7 +13980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13991,7 +13996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14011,7 +14016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14024,7 +14029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14035,7 +14040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14050,7 +14055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14066,7 +14071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14082,7 +14087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14097,7 +14102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14113,7 +14118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14128,7 +14133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14144,7 +14149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14159,11 +14164,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_161bdf25-9925-431e-b52b-1827e6e5d218_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14171,7 +14176,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ae218896-da4c-4082-a729-8e8537eff988_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/161bdf25-9925-431e-b52b-1827e6e5d218_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN>
@@ -14193,7 +14198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14209,7 +14214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14229,7 +14234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14245,7 +14250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14268,7 +14273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14284,7 +14289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14300,7 +14305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14314,7 +14319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14336,7 +14341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14352,7 +14357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14375,7 +14380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14391,7 +14396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14407,7 +14412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14421,7 +14426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14437,7 +14442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14452,7 +14457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14465,7 +14470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14479,7 +14484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14490,12 +14495,29 @@
           <http://model.geneontology.org/YeastPathways_PRPP-PWY-1/YeastPathways_PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/161bdf25-9925-431e-b52b-1827e6e5d218_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14507,7 +14529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14523,7 +14545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14551,7 +14573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14567,7 +14589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14583,7 +14605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14592,7 +14614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14603,7 +14625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14621,7 +14643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14634,7 +14656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14647,7 +14669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14662,7 +14684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14678,7 +14700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14698,7 +14720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14714,7 +14736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14730,7 +14752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14744,7 +14766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14758,7 +14780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14780,7 +14802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14793,7 +14815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14810,7 +14832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14826,7 +14848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14842,7 +14864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14853,7 +14875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14867,7 +14889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14883,7 +14905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14897,7 +14919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14919,7 +14941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14938,7 +14960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14968,7 +14990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14988,7 +15010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15003,7 +15025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15019,7 +15041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15038,7 +15060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15052,7 +15074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15064,7 +15086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15080,7 +15102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15095,7 +15117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15112,7 +15134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15139,7 +15161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15156,7 +15178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15172,7 +15194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15188,7 +15210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15213,7 +15235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15226,7 +15248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15240,7 +15262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15260,7 +15282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15276,7 +15298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15292,7 +15314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15306,7 +15328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15322,7 +15344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15337,7 +15359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15350,7 +15372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15361,7 +15383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15378,7 +15400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15397,7 +15419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15425,7 +15447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15438,7 +15460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15455,7 +15477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15475,7 +15497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15491,7 +15513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15510,7 +15532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15540,7 +15562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15560,7 +15582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15576,7 +15598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15592,7 +15614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15604,7 +15626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15620,7 +15642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15630,11 +15652,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15642,7 +15664,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
@@ -15654,7 +15676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15670,7 +15692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15690,7 +15712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15707,7 +15729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15734,7 +15756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15747,7 +15769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15761,7 +15783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15777,7 +15799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15792,7 +15814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15808,7 +15830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15827,7 +15849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15843,7 +15865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15860,7 +15882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15880,7 +15902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15893,7 +15915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15907,7 +15929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15937,7 +15959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15954,7 +15976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15970,7 +15992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15990,7 +16012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16003,7 +16025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16028,7 +16050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16044,7 +16066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16063,7 +16085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16079,7 +16101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16093,7 +16115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16113,7 +16135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16126,7 +16148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16140,7 +16162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16159,7 +16181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16181,7 +16203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16201,7 +16223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16214,7 +16236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16225,7 +16247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16239,7 +16261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16255,7 +16277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16269,7 +16291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16285,7 +16307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16302,7 +16324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16321,7 +16343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16340,7 +16362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16359,7 +16381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16377,7 +16399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16393,7 +16415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16411,7 +16433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16424,7 +16446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16439,7 +16461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16452,7 +16474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16469,7 +16491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16485,7 +16507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16496,7 +16518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16507,7 +16529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16521,7 +16543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16537,7 +16559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -16552,7 +16574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16568,7 +16590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16582,7 +16604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16601,7 +16623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16615,7 +16637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16633,7 +16655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16648,7 +16670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16665,7 +16687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16681,7 +16703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16699,7 +16721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16715,7 +16737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16731,7 +16753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16745,7 +16767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16761,7 +16783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16772,7 +16794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16783,7 +16805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16797,7 +16819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16816,7 +16838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16832,7 +16854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16846,7 +16868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16862,7 +16884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16873,7 +16895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16884,7 +16906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16895,7 +16917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16909,7 +16931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16928,7 +16950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16939,7 +16961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16953,7 +16975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16975,7 +16997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16993,7 +17015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17012,7 +17034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17024,7 +17046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17043,7 +17065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17059,7 +17081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17070,7 +17092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17083,13 +17105,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -17099,7 +17124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17115,7 +17140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17129,7 +17154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17145,7 +17170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17159,7 +17184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17179,7 +17204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17192,7 +17217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17206,7 +17231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17226,7 +17251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17242,7 +17267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17264,7 +17289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17283,7 +17308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17305,7 +17330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17320,7 +17345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17333,7 +17358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17346,7 +17371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17359,7 +17384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17373,7 +17398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17389,18 +17414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_27cef36d-dad3-4424-ab27-c69edad9ec44_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17411,7 +17425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17428,7 +17442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17439,7 +17453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17452,7 +17466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17467,7 +17481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -17483,7 +17497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17505,7 +17519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17521,7 +17535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17538,7 +17552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17557,7 +17571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17572,7 +17586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17588,7 +17602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17604,7 +17618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17618,7 +17632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17634,7 +17648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -17643,7 +17657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17671,7 +17685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17687,7 +17701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17703,7 +17717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17714,7 +17728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17729,7 +17743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17745,7 +17759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17768,24 +17782,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40428> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6d1c36d3-bcc1-4358-bda3-92984bbdeed2_GART-RXN_SGD_PWY_YeastPathways_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -17795,7 +17798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17813,7 +17816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17826,7 +17829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17837,7 +17840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17848,7 +17851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17862,7 +17865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17884,7 +17887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17903,7 +17906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17919,7 +17922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17933,7 +17936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17952,7 +17955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-1801-1.ttl
+++ b/models/YeastPathways_PWY-1801-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -359,26 +359,26 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://identifiers.org/sgd/S000003604>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_RO_0002233_CHEBI_15377_S-FORMYLGLUTATHIONE-HYDROLASE-RXN_SGD_PWY_YeastPathways_PWY-1801-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003604>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN-2962_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1244,7 +1244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "formaldehyde oxidation II (glutathione-dependent) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-2201.ttl
+++ b/models/YeastPathways_PWY-2201.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
@@ -6,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,15 +34,26 @@
 <http://purl.obolibrary.org/obo/GO_0004372>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,21 +61,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,11 +99,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +111,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -100,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -108,6 +127,17 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_d1a4eb2f-2458-414f-b23c-b8abfd522112_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -117,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,18 +216,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_95b824d1-9b06-4215-b9d5-5def42b8e91c_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +232,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/95b824d1-9b06-4215-b9d5-5def42b8e91c_FORMYLTHFDEFORMYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -213,18 +240,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000042>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,11 +302,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +314,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
@@ -292,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -304,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -316,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,16 +360,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_6cefe9d3-fd0e-4801-a855-1674fc8e4bbe_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/60fd0d58-31a3-4679-b875-dd7e45cd0f5e_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -349,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,23 +403,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
-
-<http://model.geneontology.org/bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -389,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,11 +428,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +440,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -421,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -437,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,19 +472,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_63606_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -473,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -494,6 +532,9 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/a8e6569a-0eb1-402e-a060-00bb9e0817c8_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -503,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,15 +583,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> , <http://model.geneontology.org/2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15378_RXN-5061> ;
+                <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> , <http://model.geneontology.org/CHEBI_15378_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> , <http://model.geneontology.org/d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061> ;
+                <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> , <http://model.geneontology.org/b5a4ee3a-0a7f-4724-a6c7-acd177461fbc_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/HOMOCYSMETB12-RXN> , <http://model.geneontology.org/2.1.1.19-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,34 +604,70 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/fbde322e-a673-4125-84dd-78eb13278b83_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
         a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -600,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,41 +692,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,17 +706,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -683,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,15 +727,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004487>
+<http://purl.obolibrary.org/obo/CHEBI_134413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,23 +775,15 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -764,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -777,24 +805,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201Protein67693> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -804,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -874,24 +891,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67759> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -901,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,12 +918,23 @@
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_1b12aa63-60d2-43c6-8034-fe0beadab023_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -926,29 +943,15 @@
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,15 +959,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_c41de9af-843e-443b-9ab9-4de299ca7391_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_30616_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -975,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -985,11 +999,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +1011,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY_YeastPathways_PWY-2201>
@@ -1005,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1017,9 +1031,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1029,17 +1040,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/28174478-837b-41cb-9eb5-be6cf3335ef7_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,12 +1058,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_1b12aa63-60d2-43c6-8034-fe0beadab023_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1b12aa63-60d2-43c6-8034-fe0beadab023_2.1.1.19-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_Reduced-ferredoxins_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,30 +1126,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,18 +1138,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1162,11 +1173,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_31bc3a47-6103-4f35-93f5-4ce10a31dde3_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,7 +1185,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/31bc3a47-6103-4f35-93f5-4ce10a31dde3_HOMOCYSMETB12-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -1182,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1265,11 +1276,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_d1a4eb2f-2458-414f-b23c-b8abfd522112_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,29 +1288,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN>
+          <http://model.geneontology.org/d1a4eb2f-2458-414f-b23c-b8abfd522112_1.5.1.20-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,21 +1307,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
-
-<http://model.geneontology.org/3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1326,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
@@ -1344,9 +1341,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/c41de9af-843e-443b-9ab9-4de299ca7391_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1354,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,12 +1378,23 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1409,12 +1417,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,39 +1464,31 @@
           <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000000042> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5-methyltetrahydrofolate + NAD<sup>+</sup> &larr; a 5,10-methylenetetrahydrofolate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1492,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,7 +1522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,11 +1537,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_b5a4ee3a-0a7f-4724-a6c7-acd177461fbc_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,7 +1549,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d898a63e-b68f-480d-9cbc-9fd461ab6ac4_RXN-5061>
+          <http://model.geneontology.org/b5a4ee3a-0a7f-4724-a6c7-acd177461fbc_RXN-5061>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -1546,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1560,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1585,18 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1607,38 +1607,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1640,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -1654,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1659,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_60fd0d58-31a3-4679-b875-dd7e45cd0f5e_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1675,11 +1680,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_CHEBI_63606_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,7 +1692,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_63606_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1698,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1709,17 +1714,6 @@
           <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1729,15 +1723,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/9a6aad90-b51e-4035-9846-f8b3b448ffb0_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1750,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1760,11 +1754,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_9a6aad90-b51e-4035-9846-f8b3b448ffb0_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1766,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/9a6aad90-b51e-4035-9846-f8b3b448ffb0_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1783,7 +1777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1808,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1832,11 +1826,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,32 +1838,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1878,29 +1866,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1980,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2017,7 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,6 +1999,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
@@ -2036,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2051,11 +2025,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2063,29 +2037,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,28 +2086,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0047147>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2149,7 +2103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,19 +2133,58 @@
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/c41de9af-843e-443b-9ab9-4de299ca7391_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_9a6aad90-b51e-4035-9846-f8b3b448ffb0_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2204,7 +2197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,11 +2215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,40 +2227,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/31bc3a47-6103-4f35-93f5-4ce10a31dde3_HOMOCYSMETB12-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,32 +2263,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2314,7 +2285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2333,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2347,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2358,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2373,15 +2344,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_63606_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/fbde322e-a673-4125-84dd-78eb13278b83_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2398,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2415,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2430,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2441,6 +2412,17 @@
 <http://purl.obolibrary.org/obo/GO_0030272>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a8e6569a-0eb1-402e-a060-00bb9e0817c8_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
@@ -2449,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2468,7 +2450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2499,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2510,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2524,7 +2506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,31 +2516,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2575,7 +2532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate transformations I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2590,11 +2547,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_CHEBI_15377_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,15 +2559,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_63606>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_28174478-837b-41cb-9eb5-be6cf3335ef7_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
         a       <http://identifiers.org/sgd/S000004801> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2622,7 +2593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,7 +2612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2661,34 +2632,23 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/c2f01dbd-7983-4ea7-949f-051662f986ce_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/1.5.1.15-RXN> , <http://model.geneontology.org/RXN-5061> , <http://model.geneontology.org/1.5.1.20-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/1.5.1.15-RXN> , <http://model.geneontology.org/1.5.1.20-RXN> , <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/RXN-5061> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67696> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2699,7 +2659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2712,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2726,7 +2686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2746,15 +2706,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/6cefe9d3-fd0e-4801-a855-1674fc8e4bbe_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/31bc3a47-6103-4f35-93f5-4ce10a31dde3_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2770,7 +2730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2784,15 +2744,43 @@
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/05d93a3f-339c-45bf-884f-a8f85ac518a6_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_fbde322e-a673-4125-84dd-78eb13278b83_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2800,7 +2788,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_CHEBI_15378_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -2808,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2825,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2836,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2850,7 +2838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,12 +2849,23 @@
           <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2876,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_95b824d1-9b06-4215-b9d5-5def42b8e91c_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2891,7 +2901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2922,13 +2932,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67402> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2938,7 +2951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2958,7 +2971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2966,12 +2979,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2985,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3016,28 +3040,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67622> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3046,7 +3053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3060,7 +3067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,14 +3081,8 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/6cefe9d3-fd0e-4801-a855-1674fc8e4bbe_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
@@ -3090,7 +3091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3106,7 +3107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,7 +3126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3136,12 +3137,29 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_63606_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_63606> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3156,9 +3174,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/05d93a3f-339c-45bf-884f-a8f85ac518a6_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3166,30 +3184,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67448> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/d29252c4-1940-4f8a-966d-03631e249f8c_HOMOCYSMETB12-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3199,7 +3200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3214,11 +3215,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3226,19 +3227,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3248,7 +3238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3264,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3273,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3286,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3302,7 +3292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3318,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3329,7 +3319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3339,11 +3329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_c41de9af-843e-443b-9ab9-4de299ca7391_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3351,7 +3341,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/c41de9af-843e-443b-9ab9-4de299ca7391_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -3361,7 +3351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3374,11 +3364,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3390,11 +3397,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c2f01dbd-7983-4ea7-949f-051662f986ce_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3402,18 +3409,46 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ed58414b-a8c5-4284-89b8-27a71294ee78_2.1.1.19-RXN>
+          <http://model.geneontology.org/c2f01dbd-7983-4ea7-949f-051662f986ce_2.1.1.19-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/d1a4eb2f-2458-414f-b23c-b8abfd522112_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_28174478-837b-41cb-9eb5-be6cf3335ef7_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3421,8 +3456,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN>
+          <http://model.geneontology.org/28174478-837b-41cb-9eb5-be6cf3335ef7_2.1.1.19-RXN>
 ] .
+
+<http://model.geneontology.org/c2f01dbd-7983-4ea7-949f-051662f986ce_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -3433,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3449,7 +3487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3468,7 +3506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3487,7 +3525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3498,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3515,7 +3553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3541,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3557,7 +3595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3576,7 +3614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3591,11 +3629,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,7 +3641,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_CHEBI_58199_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -3611,7 +3649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3619,23 +3657,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3645,7 +3666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3660,11 +3681,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3693,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -3680,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3691,7 +3712,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_31bc3a47-6103-4f35-93f5-4ce10a31dde3_HOMOCYSMETB12-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3702,18 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3724,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3733,31 +3754,31 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/1b12aa63-60d2-43c6-8034-fe0beadab023_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/0a2c0d03-fa2e-4ac9-8d84-45eaa17420b4_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0008705>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3770,7 +3791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3790,7 +3811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3803,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3811,17 +3832,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3833,7 +3854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3846,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3856,17 +3877,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3881,7 +3902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,37 +3913,15 @@
           <http://model.geneontology.org/HOMOCYSMETB12-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_05d93a3f-339c-45bf-884f-a8f85ac518a6_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3930,7 +3929,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aa8ee7f8-79fe-4187-b471-59584b9c0cf1_1.5.1.15-RXN>
+          <http://model.geneontology.org/05d93a3f-339c-45bf-884f-a8f85ac518a6_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY-2201>
@@ -3938,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3952,7 +3951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3966,7 +3965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3982,7 +3981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3993,7 +3992,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4002,9 +4012,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/b5a4ee3a-0a7f-4724-a6c7-acd177461fbc_RXN-5061>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4014,7 +4041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4033,7 +4060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4044,12 +4071,29 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
+<http://model.geneontology.org/9a6aad90-b51e-4035-9846-f8b3b448ffb0_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4063,7 +4107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4074,29 +4118,12 @@
           <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
 ] .
 
-<http://model.geneontology.org/eb7de80b-10d9-4db2-9ba1-31e583c76710_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY-2201/YeastPathways_PWY-2201_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4110,7 +4137,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4121,7 +4159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4136,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4153,13 +4191,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67438> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -4173,9 +4244,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/a8e6569a-0eb1-402e-a060-00bb9e0817c8_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -4183,24 +4254,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67577> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4210,7 +4270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4230,15 +4290,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/60fd0d58-31a3-4679-b875-dd7e45cd0f5e_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> , <http://model.geneontology.org/1b12aa63-60d2-43c6-8034-fe0beadab023_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/GCVMULTI-RXN> , <http://model.geneontology.org/FORMATETHFLIG-RXN> , <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4253,7 +4313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4266,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4280,7 +4340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4291,29 +4351,29 @@
           <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_c42d4043-e0a3-4ef1-91ec-f3afdc7e1218_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c2f01dbd-7983-4ea7-949f-051662f986ce_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4321,7 +4381,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201>
@@ -4329,18 +4389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4351,18 +4400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4377,24 +4415,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67438> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_2e58b3a5-dc45-4359-886b-30e53e87ed1c_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4405,7 +4432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4417,11 +4444,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_60fd0d58-31a3-4679-b875-dd7e45cd0f5e_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4429,7 +4456,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN>
+          <http://model.geneontology.org/60fd0d58-31a3-4679-b875-dd7e45cd0f5e_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4440,7 +4467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4456,7 +4483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4465,15 +4492,32 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/95b824d1-9b06-4215-b9d5-5def42b8e91c_FORMYLTHFDEFORMYL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_6cefe9d3-fd0e-4801-a855-1674fc8e4bbe_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4481,7 +4525,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3fc96e1e-191a-4659-b874-33bf2f6cfc0c_1.5.1.20-RXN>
+          <http://model.geneontology.org/6cefe9d3-fd0e-4801-a855-1674fc8e4bbe_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4492,7 +4536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4503,17 +4547,6 @@
           <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57844> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4523,7 +4556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4534,29 +4567,23 @@
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/0662b20e-0b2e-44d1-95b2-7a24a7070447_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4564,30 +4591,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ca399521-de2c-4a92-8303-26a39ffb8c8c_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4595,26 +4603,45 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_fbde322e-a673-4125-84dd-78eb13278b83_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/fbde322e-a673-4125-84dd-78eb13278b83_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_b5a4ee3a-0a7f-4724-a6c7-acd177461fbc_RXN-5061_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_fde4e683-e413-4a0d-9435-e31ff7976df6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4623,7 +4650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4638,9 +4665,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bd814a43-3d8f-4ee1-90bf-eb2a8e580a88_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/d1a4eb2f-2458-414f-b23c-b8abfd522112_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4648,7 +4675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4664,7 +4691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4682,7 +4709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4697,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4710,7 +4737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4723,15 +4750,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/3ac7201d-b44a-46d8-af7c-d476dff1cca6_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/95b824d1-9b06-4215-b9d5-5def42b8e91c_FORMYLTHFDEFORMYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4744,28 +4771,17 @@
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201Complex67628> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_ce0541ae-13fe-4eaa-90cd-6e13662be5a6_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4775,7 +4791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4791,7 +4807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4809,7 +4825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4829,38 +4845,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67378> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_94dd851d-9307-4fb4-9907-6b086fd3a5c5_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e85f3c0a-1891-4428-a938-1a81de9823da_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/d9d483ea-ef26-4f9f-943e-507b448a9557_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4870,7 +4861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4878,17 +4869,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5-methyltetrahydrofolate + 2 an oxidized ferredoxin [iron-sulfur] cluster &larr; a 5,10-methylenetetrahydrofolate + 2 a reduced ferredoxin [iron-sulfur] cluster + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_RXN-5061_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4900,7 +4891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4909,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4920,7 +4911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4935,7 +4926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4945,17 +4936,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+          "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4970,7 +4961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4981,8 +4972,16 @@
           <http://model.geneontology.org/2.1.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/2f5c7704-ffa6-4ace-aa2f-c0a1f428a73f_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_05d93a3f-339c-45bf-884f-a8f85ac518a6_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4992,7 +4991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5003,23 +5002,12 @@
           <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_295f5d5a-6021-49e9-96d5-d14359b94cbf_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -5034,7 +5022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5049,11 +5037,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5061,39 +5049,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
-
-<http://model.geneontology.org/bddddb7e-573d-4af0-a850-b029bb1efb00_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000066_reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5103,7 +5071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5122,7 +5090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5141,7 +5109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5159,11 +5127,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5171,7 +5139,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6f7b502f-fcca-490f-91b7-b2d4fc577f70_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
@@ -5183,7 +5151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5203,11 +5171,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67378> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -5219,7 +5204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5230,16 +5215,8 @@
           <http://model.geneontology.org/YeastPathways_PWY-2201/YeastPathways_PWY-2201>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_1462aa25-c1ef-4ce0-8eab-b16aca2c6726_FORMYLTHFDEFORMYL-RXN_SGD_PWY_YeastPathways_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://model.geneontology.org/28174478-837b-41cb-9eb5-be6cf3335ef7_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -5250,7 +5227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5262,11 +5239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a8e6569a-0eb1-402e-a060-00bb9e0817c8_2.1.1.19-RXN_SGD_PWY_YeastPathways_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5274,8 +5251,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9346407b-b052-414b-9b71-7fda69fc7598_2.1.1.19-RXN>
+          <http://model.geneontology.org/a8e6569a-0eb1-402e-a060-00bb9e0817c8_2.1.1.19-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5286,7 +5280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-2301.ttl
+++ b/models/YeastPathways_PWY-2301.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>myo</i>-inositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-3322.ttl
+++ b/models/YeastPathways_PWY-3322.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation IX - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-3322" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-46.ttl
+++ b/models/YeastPathways_PWY-46.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "putrescine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-5041.ttl
+++ b/models/YeastPathways_PWY-5041.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,6 +176,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
@@ -184,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,8 +198,16 @@
           <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_0e73a6ba-d1f8-4e90-b0ae-0e042efdcc5e_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_S-ADENMETSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -207,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>S</i>-adenosyl-L-methionine cycle II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -402,28 +413,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a methylated methyl donor" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30392> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/CHEBI_142491>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -433,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,15 +553,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7605_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN> , <http://model.geneontology.org/15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605> ;
+                <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN> , <http://model.geneontology.org/CHEBI_142491_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
+                <http://model.geneontology.org/0e73a6ba-d1f8-4e90-b0ae-0e042efdcc5e_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/ADENOSYLHOMOCYSTEINASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -577,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -589,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -648,11 +645,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_142491_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +657,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
+          <http://model.geneontology.org/CHEBI_142491_RXN-7605>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -674,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,22 +682,52 @@
           <http://model.geneontology.org/YeastPathways_PWY-5041/YeastPathways_PWY-5041>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_142491_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_142491_RXN-7605>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_142491> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -708,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,30 +747,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -792,11 +800,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_CHEBI_59789_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +812,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605>
+          <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY-5041>
@@ -812,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1034,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,15 +1081,6 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
@@ -1090,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,6 +1100,32 @@
           <http://model.geneontology.org/YeastPathways_PWY-5041/YeastPathways_PWY-5041>
 ] .
 
+<http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/0e73a6ba-d1f8-4e90-b0ae-0e042efdcc5e_RXN-7605>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a methylated methyl donor" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30392> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
@@ -1109,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,28 +1185,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30477> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1191,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,6 +1210,23 @@
           <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_43474_S-ADENMETSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30477> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YER091C-MONOMER_HOMOCYSMET-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000893> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1209,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1288,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1308,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1379,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1426,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1440,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1451,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1463,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1482,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1519,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,42 +1555,11 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_15b3ba84-75cd-48f2-81fb-87d4ccec1eb7_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16335> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenosine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30438> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1575,7 +1569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,23 +1580,32 @@
           <http://model.geneontology.org/reaction_HOMOCYSMET-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605_SGD_PWY_YeastPathways_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_16335_ADENOSYLHOMOCYSTEINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16335> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenosine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5041" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30438> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_15377_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1612,11 +1615,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_0e73a6ba-d1f8-4e90-b0ae-0e042efdcc5e_RXN-7605_SGD_PWY_YeastPathways_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1624,7 +1627,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4889558f-1065-449f-b84a-e7b56504cc28_RXN-7605>
+          <http://model.geneontology.org/0e73a6ba-d1f8-4e90-b0ae-0e042efdcc5e_RXN-7605>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002413_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-5041>
@@ -1632,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1646,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1657,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5041" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5080-1.ttl
+++ b/models/YeastPathways_PWY-5080-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -11,17 +11,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -31,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,18 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -72,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,20 +121,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-101_RXN3O-9814_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002173> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "enoyl-CoA reductase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,15 +153,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57783_RXN3O-9812> , <http://model.geneontology.org/CHEBI_15489_RXN3O-9811> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812> ;
+                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/CHEBI_65260_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9813> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,30 +169,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000003633>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000003633>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/7f0093d4-6dee-4f94-934f-a2002ae5ddf9_RXN3O-9813>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-70_RXN3O-9811_controller>
         a       <http://identifiers.org/sgd/S000004364> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -223,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -245,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -256,21 +240,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/CHEBI_65260>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_CHEBI_65260_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +265,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812>
+          <http://model.geneontology.org/CHEBI_65260_RXN3O-9812>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9812>
@@ -290,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,6 +307,23 @@
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_65260_RXN3O-9812>
+        a       <http://purl.obolibrary.org/obo/CHEBI_65260> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 3-hydroxyacyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -338,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,23 +457,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_33184_RXN3O-9814>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33184> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a long-chain acyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75512> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-9811>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102756> ;
@@ -490,13 +477,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1BiochemicalReaction75583> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_33184_RXN3O-9814>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33184> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a long-chain acyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75512> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -516,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -563,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,19 +578,22 @@
           <http://model.geneontology.org/MONOMER3O-101_RXN3O-9814_controller>
 ] .
 
+<http://model.geneontology.org/60c96992-ce53-4420-8101-e65f1a8833af_RXN3O-9813>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" , "Provides Input For Rule. The relation 'a 3-oxoacyl-CoA + NADPH + H<SUP>+</SUP> &rarr; a 3-hydroxyacyl-CoA + NADP<sup>+</sup>' 'null' 'a 3-hydroxyacyl-CoA &rarr; a <i>trans</i>-2-enoyl-CoA + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002411_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002413_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9812> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -604,7 +611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,29 +622,23 @@
           <http://model.geneontology.org/YCR034W-MONOMER_RXN3O-9811_controller>
 ] .
 
-<http://model.geneontology.org/0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1_SGD_PWY_YeastPathways_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_60c96992-ce53-4420-8101-e65f1a8833af_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -648,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -677,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,13 +773,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75504> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_CHEBI_65260_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -789,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "very long chain fatty acid biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +817,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_CHEBI_65260_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -819,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -848,30 +871,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1Protein75580> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 3-hydroxyacyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -881,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,18 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002411_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -922,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,13 +1034,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75612> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000002173>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1055,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1078,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1133,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002413_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,11 +1232,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_CHEBI_65260_RXN3O-9812_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1244,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9812> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7401a812-baf9-425d-8c4e-b8f4e219b0f0_RXN3O-9812>
+          <http://model.geneontology.org/CHEBI_65260_RXN3O-9812>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1246,7 +1255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,9 +1269,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1275,7 +1281,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9814_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> , <http://model.geneontology.org/6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813> ;
+                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> , <http://model.geneontology.org/60c96992-ce53-4420-8101-e65f1a8833af_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9814> , <http://model.geneontology.org/CHEBI_33184_RXN3O-9814> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1283,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,7 +1305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,18 +1335,15 @@
           <http://model.geneontology.org/YeastPathways_PWY-5080-1/YeastPathways_PWY-5080-1>
 ] .
 
-<http://model.geneontology.org/5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_7f0093d4-6dee-4f94-934f-a2002ae5ddf9_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,7 +1351,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813>
+          <http://model.geneontology.org/7f0093d4-6dee-4f94-934f-a2002ae5ddf9_RXN3O-9813>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1359,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,18 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5080-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1442,15 +1434,12 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1458,11 +1447,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_60c96992-ce53-4420-8101-e65f1a8833af_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,7 +1459,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6b94ccc8-763c-4901-8202-082c904fc57a_RXN3O-9813>
+          <http://model.geneontology.org/60c96992-ce53-4420-8101-e65f1a8833af_RXN3O-9813>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0042761>
@@ -1481,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1498,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,9 +1556,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5871b142-e49f-43f1-83da-a50512067ef1_RXN3O-9812> ;
+                <http://model.geneontology.org/CHEBI_65260_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> , <http://model.geneontology.org/0ef64807-fcaf-40f8-8e86-d96caaf2e19e_RXN3O-9813> ;
+                <http://model.geneontology.org/7f0093d4-6dee-4f94-934f-a2002ae5ddf9_RXN3O-9813> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-85_RXN3O-9813_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1577,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,7 +1582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,6 +1596,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_7f0093d4-6dee-4f94-934f-a2002ae5ddf9_RXN3O-9813_SGD_PWY_YeastPathways_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
@@ -1615,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1645,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5084.ttl
+++ b/models/YeastPathways_PWY-5084.ttl
@@ -1,3 +1,6 @@
+<http://model.geneontology.org/6c661dc3-19f4-4c62-bb2b-c12049085796_RXN-7716>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://identifiers.org/sgd/S000002555>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6,7 +9,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -16,11 +19,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_cd750187-feb5-4a73-921f-86c8a1225bb2_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,11 +31,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/cd750187-feb5-4a73-921f-86c8a1225bb2_2OXOGLUTDECARB-RXN>
 ] .
-
-<http://model.geneontology.org/d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -100,9 +100,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_57945_RXN-7716>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -112,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,6 +119,9 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/cd750187-feb5-4a73-921f-86c8a1225bb2_2OXOGLUTDECARB-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,29 +145,12 @@
           <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -182,9 +165,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/6c661dc3-19f4-4c62-bb2b-c12049085796_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/121a0f5a-9354-4e98-a734-cce03fe9a16e_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -192,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,18 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -242,28 +214,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller>
         a       <http://identifiers.org/sgd/S000001876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -272,13 +227,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084Protein17009> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_121a0f5a-9354-4e98-a734-cce03fe9a16e_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -289,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,23 +335,23 @@
 <http://purl.obolibrary.org/obo/GO_0004149>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002411_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002333_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,9 +399,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/cd750187-feb5-4a73-921f-86c8a1225bb2_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57292_RXN0-1147> , <http://model.geneontology.org/65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57292_RXN0-1147> , <http://model.geneontology.org/dd4f4fc5-939e-4c6c-8292-3a5ed6a9a52e_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -443,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,26 +464,15 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57292_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_a170e41e-f19a-46f4-b7d7-6deb3688d91a_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,26 +480,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716>
+          <http://model.geneontology.org/a170e41e-f19a-46f4-b7d7-6deb3688d91a_RXN-7716>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_a3c6e8b3-4d6a-4725-ae32-4afca62b89ef_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57292_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,11 +556,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_121a0f5a-9354-4e98-a734-cce03fe9a16e_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +568,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/121a0f5a-9354-4e98-a734-cce03fe9a16e_2OXOGLUTDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
@@ -632,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -641,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -658,18 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_8f713ada-e1c4-4bd1-a41b-2e111971063d_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,17 +643,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-5084/YeastPathways_PWY-5084>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -736,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,6 +786,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_cd750187-feb5-4a73-921f-86c8a1225bb2_2OXOGLUTDECARB-RXN_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -880,9 +813,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/a18e82b6-2d64-4d85-82a4-12af0de65dda_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
+                <http://model.geneontology.org/a170e41e-f19a-46f4-b7d7-6deb3688d91a_RXN-7716> , <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -890,24 +823,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084BiochemicalReaction16943> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -924,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,15 +860,43 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_a170e41e-f19a-46f4-b7d7-6deb3688d91a_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/dd4f4fc5-939e-4c6c-8292-3a5ed6a9a52e_RXN0-1147>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_dd4f4fc5-939e-4c6c-8292-3a5ed6a9a52e_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +904,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/65779864-6e2e-46b9-96f8-2d924568e8bb_RXN0-1147>
+          <http://model.geneontology.org/dd4f4fc5-939e-4c6c-8292-3a5ed6a9a52e_RXN0-1147>
 ] .
 
 <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
@@ -962,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -974,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1005,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1018,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,8 +1076,22 @@
           <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
 ] .
 
-<http://model.geneontology.org/a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/121a0f5a-9354-4e98-a734-cce03fe9a16e_2OXOGLUTDECARB-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YeastPathways_PWY-5084/YeastPathways_PWY-5084>
         a       <http://purl.obolibrary.org/obo/GO_0045333> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1136,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1148,11 +1112,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_6c661dc3-19f4-4c62-bb2b-c12049085796_RXN-7716_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1124,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d9a754f7-9ea3-4e59-80dd-08f2693afce0_RXN-7716>
+          <http://model.geneontology.org/6c661dc3-19f4-4c62-bb2b-c12049085796_RXN-7716>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1178,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "2-oxoglutarate decarboxylation to succinyl-CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1189,6 +1153,20 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_6c661dc3-19f4-4c62-bb2b-c12049085796_RXN-7716_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/a18e82b6-2d64-4d85-82a4-12af0de65dda_RXN0-1147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1197,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1238,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1248,11 +1226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_a18e82b6-2d64-4d85-82a4-12af0de65dda_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,8 +1238,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a64f02ef-3308-41e9-bc0c-d47d61961f54_RXN0-1147>
+          <http://model.geneontology.org/a18e82b6-2d64-4d85-82a4-12af0de65dda_RXN0-1147>
 ] .
+
+<http://model.geneontology.org/a170e41e-f19a-46f4-b7d7-6deb3688d91a_RXN-7716>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -1272,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,19 +1333,24 @@
           <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/27a72130-d12c-4aaa-b7f2-7d49395770ac_RXN-7716>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_dd4f4fc5-939e-4c6c-8292-3a5ed6a9a52e_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_a18e82b6-2d64-4d85-82a4-12af0de65dda_RXN0-1147_SGD_PWY_YeastPathways_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5123.ttl
+++ b/models/YeastPathways_PWY-5123.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>trans, trans</i>-farnesyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5123" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5177.ttl
+++ b/models/YeastPathways_PWY-5177.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,17 +20,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0003985>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -49,13 +38,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177BiochemicalReaction43643> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-ACETYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +82,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -340,30 +340,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTARYL-COA-DEHYDROG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-5177/YeastPathways_PWY-5177>
-] .
 
 <http://model.geneontology.org/CHEBI_16526_GLUTACONYL-COA-DECARBOXYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -374,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -382,12 +363,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_BFO_0000050_YeastPathways_PWY-5177/YeastPathways_PWY-5177_SGD_PWY_YeastPathways_PWY-5177> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUTARYL-COA-DEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-5177/YeastPathways_PWY-5177>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-11667_RO_0002234_CHEBI_57316_RXN-11667_SGD_PWY_YeastPathways_PWY-5177>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,13 +565,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43639> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -585,22 +594,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43611> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -868,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -898,7 +898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1064,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,7 +1098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,7 +1159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutaryl-CoA degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1238,7 +1238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1301,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1315,7 +1315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,13 +1453,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177BiochemicalReaction43715> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002413_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1469,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,17 +1491,6 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11662_RO_0002413_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
@@ -1499,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1568,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-5194-1.ttl
+++ b/models/YeastPathways_PWY-5194-1.ttl
@@ -9,7 +9,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -105,13 +105,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000417> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ferrochelatase / precorrin-2 dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -778,20 +778,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001777> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "uroporphyrinogen-III C-methyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -839,13 +839,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41701> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -858,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,15 +872,15 @@
           <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://identifiers.org/sgd/S000000417>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002234_CHEBI_15378_RXN-13403_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,21 +910,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DIMETHUROPORDEHYDROG-RXN_BFO_0000066_reaction_DIMETHUROPORDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5194-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -987,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,6 +998,9 @@
           <http://model.geneontology.org/CHEBI_60052_SIROHEME-FERROCHELAT-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000001777>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1006,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1019,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,13 +1198,13 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000000417> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ferrochelatase / precorrin-2 dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5340.ttl
+++ b/models/YeastPathways_PWY-5340.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -180,19 +180,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-5340>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate activation (for sulfonation) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5340" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5344.ttl
+++ b/models/YeastPathways_PWY-5344.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homocysteine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -647,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5344" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5651.ttl
+++ b/models/YeastPathways_PWY-5651.ttl
@@ -9,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation to 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -940,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1111,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1277,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1291,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1321,7 +1321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1350,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1554,7 +1554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1603,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1615,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,7 +1708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,7 +1774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1821,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1855,7 +1855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1933,7 +1933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1952,7 +1952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1968,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2023,7 +2023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2042,7 +2042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2089,6 +2089,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5653.ttl
+++ b/models/YeastPathways_PWY-5653.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -886,7 +886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1014,7 +1014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1044,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1125,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1431,7 +1431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1550,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,7 +1569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1664,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1692,7 +1692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,7 +1711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1741,7 +1741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD biosynthesis from 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1822,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5653" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5669.ttl
+++ b/models/YeastPathways_PWY-5669.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,8 +79,28 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_17962>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17962> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -90,7 +110,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -158,9 +189,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -174,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,7 +255,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -237,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,23 +337,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_BFO_0000050_YeastPathways_PWY-5669/YeastPathways_PWY-5669_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,29 +393,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PWY_YeastPathways_PWY-5669>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,11 +475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ac277f6b-34f4-47a4-becf-771c82de5f65_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -498,7 +498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylethanolamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,39 +621,15 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylserine decarboxylase, mitochondria" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21652> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,8 +637,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN>
 ] .
+
+<http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylserine decarboxylase, mitochondria" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669Protein21652> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5670-1.ttl
+++ b/models/YeastPathways_PWY-5670-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "epoxysqualene biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +1004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5686-1.ttl
+++ b/models/YeastPathways_PWY-5686-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1088,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1341,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1440,11 +1440,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15377_DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1455,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,30 +1486,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/OROPRIBTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_43474_CARBPSYN-RXN_SGD_PWY_YeastPathways_PWY-5686-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1561,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1602,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,7 +1679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1726,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1849,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1866,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,7 +1916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1932,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2017,7 +2017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UMP biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2094,6 +2094,17 @@
           <http://model.geneontology.org/DIHYDROOROT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5686-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2103,24 +2114,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5686-1SmallMolecule71023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_RO_0002234_CHEBI_43474_ASPCARBTRANS-RXN_SGD_PWY_YeastPathways_PWY-5686-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5686-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004884>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2130,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2139,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2151,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2231,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2285,7 +2285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2307,7 +2307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,7 +2325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2341,7 +2341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2368,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2393,7 +2393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2417,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2457,7 +2457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2476,7 +2476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2495,7 +2495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2509,7 +2509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2525,7 +2525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2550,7 +2550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2561,7 +2561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2576,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2593,7 +2593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2606,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2620,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2639,7 +2639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2664,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2675,7 +2675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2686,6 +2686,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-5694.ttl
+++ b/models/YeastPathways_PWY-5694.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to glyoxylate I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,17 +639,6 @@
           <http://model.geneontology.org/UREIDOGLYCOLATE-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5694" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
@@ -658,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,6 +658,17 @@
           <http://model.geneontology.org/CHEBI_15678_ALLANTOINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5694>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5694" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17536_ALLANTOINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17536> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,7 +694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5694" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-5697.ttl
+++ b/models/YeastPathways_PWY-5697.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>S</i>)-(+)-allantoin + H<sub>2</sub>O &rarr; allantoate + H<SUP>+</SUP>' 'null' 'allantoate + H<sub>2</sub>O &rarr; (<i>S</i>)-ureidoglycolate + urea' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
@@ -6,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,23 +28,12 @@
           <http://model.geneontology.org/ALLANTOICASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_RO_0002233_CHEBI_15678_ALLANTOINASE-RXN_SGD_PWY_YeastPathways_PWY-5697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ALLANTOINASE-RXN_BFO_0000050_YeastPathways_PWY-5697/YeastPathways_PWY-5697_SGD_PWY_YeastPathways_PWY-5697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to ureidoglycolate I (urea producing) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5703.ttl
+++ b/models/YeastPathways_PWY-5703.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,29 +37,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ammonium" ;
+<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703SmallMolecule20303> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002233_CHEBI_16199_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +67,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,23 +78,29 @@
           <http://model.geneontology.org/CHEBI_15378_UREA-CARBOXYLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UREA-CARBOXYLASE-RXN_RO_0002234_CHEBI_15832_UREA-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY-5703>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_28938_ALLOPHANATE-HYDROLASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_28938> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ammonium" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5703" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5703SmallMolecule20303> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -112,7 +112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "urea degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,7 +936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-5760-1.ttl
+++ b/models/YeastPathways_PWY-5760-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,6 +378,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5760-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5760-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY-5760-1/YeastPathways_PWY-5760-1>
         a       <http://purl.obolibrary.org/obo/GO_0019483> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -385,24 +396,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY-5760-1" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_BFO_0000066_reaction_3-PROPANAL-DEHYDROGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5760-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5760-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR170C-MONOMER_3-PROPANAL-DEHYDROGENASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004780> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "&beta;-alanine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -834,23 +834,6 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_16240_RXN-9015>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16240> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hydrogen peroxide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5760-1SmallMolecule74336> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-9015>
         a       <http://purl.obolibrary.org/obo/GO_0052904> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -871,13 +854,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5760-1BiochemicalReaction74278> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_16240_RXN-9015>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16240> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hydrogen peroxide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5760-1SmallMolecule74336> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-5971-1.ttl
+++ b/models/YeastPathways_PWY-5971-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -58,13 +58,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33143> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_CHEBI_58349_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9655>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -75,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,23 +94,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002234_CHEBI_58349_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_CHEBI_58349_RXN-9528_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -170,7 +170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,43 +193,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_57783_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9533> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -239,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,12 +220,42 @@
           <http://model.geneontology.org/Trans-D2-decenoyl-ACPs_RXN-9655>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9533_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9533> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9530_RO_0002233_CHEBI_57783_RXN-9530_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002233_CHEBI_57783_RXN-9524_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,7 +451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -509,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -716,18 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +727,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002233_ACP_RXN-9526_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,7 +965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1174,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "myristate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,7 +1580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1624,7 +1624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,7 +1718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1729,6 +1729,15 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9518>
 ] .
 
+<http://model.geneontology.org/reaction_RXN-9528_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
@@ -1737,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,21 +1757,12 @@
           <http://model.geneontology.org/ACP_RXN-9536>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-9528_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_CHEBI_57783_RXN-9538_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1773,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1815,7 +1815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1829,7 +1829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1890,7 +1890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1902,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1918,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1941,13 +1941,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1BiochemicalReaction33250> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1957,7 +1968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1973,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1988,24 +1999,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule33160> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACP_RXN-9526>
         a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2016,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2063,23 +2063,23 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9534_RO_0002233_CHEBI_57783_RXN-9534_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2093,7 +2093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2112,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2200,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2216,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2230,7 +2230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2290,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2321,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2334,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2422,43 +2422,13 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9536> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002413_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9520> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
@@ -2471,7 +2441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,11 +2456,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9520_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9520> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1_SGD_PWY_YeastPathways_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2501,6 +2490,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9524_RO_0002413_4.2.1.59-RXN_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58349_RXN-9538>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2510,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2523,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2548,7 +2548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2567,7 +2567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2578,17 +2578,6 @@
           <http://model.geneontology.org/ACP_RXN3O-8214>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_ACP_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YPL231W-MONOMER_RXN-9523_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2596,13 +2585,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33167> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002233_ACP_RXN-9531_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2612,7 +2612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2631,7 +2631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2650,7 +2650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2681,7 +2681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,7 +2700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2727,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2738,7 +2738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2749,7 +2749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2760,7 +2760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2780,7 +2780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2794,7 +2794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2810,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2833,7 +2833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2849,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2882,7 +2882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2898,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2913,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2930,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2943,7 +2943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2957,7 +2957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2973,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2988,7 +2988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3014,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3031,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3047,7 +3047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3077,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3090,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3101,7 +3101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3116,7 +3116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3129,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3143,7 +3143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3159,7 +3159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3173,7 +3173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3189,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3204,7 +3204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3220,7 +3220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3239,7 +3239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3255,7 +3255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3272,7 +3272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3291,7 +3291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,7 +3310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3326,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3340,7 +3340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3359,7 +3359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3379,7 +3379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3392,7 +3392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3407,7 +3407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3423,7 +3423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3442,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3462,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3475,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3488,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3505,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3524,7 +3524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3540,7 +3540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3565,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3581,7 +3581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3597,7 +3597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3611,7 +3611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3627,7 +3627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3641,7 +3641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3657,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3671,7 +3671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3687,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3699,7 +3699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3718,7 +3718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3746,7 +3746,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002413_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3757,18 +3768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002413_RXN-9626_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3777,7 +3777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3800,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3813,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3838,7 +3838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3858,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3874,7 +3874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3890,7 +3890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3901,7 +3901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3916,7 +3916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3933,7 +3933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,7 +3946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3960,7 +3960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3979,7 +3979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3995,7 +3995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4006,7 +4006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4021,7 +4021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4034,7 +4034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4045,7 +4045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4056,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4070,7 +4070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4089,7 +4089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4109,7 +4109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4125,7 +4125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4141,7 +4141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4152,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4163,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4177,7 +4177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4197,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4210,7 +4210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4225,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4241,7 +4241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4260,7 +4260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4276,7 +4276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4290,7 +4290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4308,7 +4308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4321,7 +4321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4346,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4359,7 +4359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4373,7 +4373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4389,7 +4389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4400,7 +4400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4411,7 +4411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4426,7 +4426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4442,7 +4442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4461,7 +4461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4479,7 +4479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4501,7 +4501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4517,7 +4517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4531,7 +4531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4547,7 +4547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4558,7 +4558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4581,7 +4581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4594,7 +4594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4608,7 +4608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4624,7 +4624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4635,7 +4635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4646,7 +4646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4657,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4670,7 +4670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4683,7 +4683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4697,7 +4697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4717,7 +4717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4730,7 +4730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4748,7 +4748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4764,7 +4764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4783,7 +4783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4802,7 +4802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4821,7 +4821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4837,7 +4837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4851,7 +4851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4870,7 +4870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4889,7 +4889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4908,7 +4908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4924,7 +4924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4949,7 +4949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4965,7 +4965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4985,7 +4985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5001,7 +5001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5020,7 +5020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5036,7 +5036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5051,24 +5051,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_ACP_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5078,7 +5067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5089,6 +5078,17 @@
           <http://model.geneontology.org/Hexanoyl-ACPs_RXN-9521>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9516_RO_0002234_ACP_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
@@ -5097,7 +5097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5113,7 +5113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5128,7 +5128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5144,7 +5144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5174,7 +5174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5187,7 +5187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5200,7 +5200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5219,7 +5219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5239,7 +5239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5255,7 +5255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5271,7 +5271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5285,7 +5285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5301,7 +5301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5315,7 +5315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5331,7 +5331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5342,7 +5342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5357,7 +5357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5370,7 +5370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5382,7 +5382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5401,7 +5401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5420,7 +5420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5437,7 +5437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5467,7 +5467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5483,7 +5483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5502,7 +5502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5513,7 +5513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5527,7 +5527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5546,7 +5546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5566,7 +5566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5583,7 +5583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5596,7 +5596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5610,7 +5610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5629,7 +5629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5648,7 +5648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5678,7 +5678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5694,7 +5694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5714,7 +5714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5730,7 +5730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5746,7 +5746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5757,7 +5757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5768,7 +5768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5782,7 +5782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5793,29 +5793,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_15378_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YPL231W-MONOMER_RXN-9516_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fatty acid synthase, alpha subunit" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_3-oxo-hexanoyl-ACPs_RXN-9516_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5829,7 +5833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5845,7 +5849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5856,26 +5860,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/YPL231W-MONOMER_RXN-9516_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fatty acid synthase, alpha subunit" ;
+<http://model.geneontology.org/ev_w_id_RXN-9518_RO_0002233_CHEBI_15378_RXN-9518_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33167> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/Trans-D2-decenoyl-ACPs_RXN-9655>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -5886,26 +5886,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33012> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/YPL231W-MONOMER_RXN-9531_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fatty acid synthase, alpha subunit" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33167> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -5917,7 +5902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5928,6 +5913,21 @@
           <http://model.geneontology.org/3-oxo-decanoyl-ACPs_RXN-9527>
 ] .
 
+<http://model.geneontology.org/YPL231W-MONOMER_RXN-9531_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006152> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fatty acid synthase, alpha subunit" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33167> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
@@ -5936,7 +5936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5956,7 +5956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5972,7 +5972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5991,7 +5991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6007,7 +6007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6021,7 +6021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6040,7 +6040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6056,7 +6056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6067,7 +6067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6081,7 +6081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6100,7 +6100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6119,7 +6119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6138,7 +6138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6154,7 +6154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6167,7 +6167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6180,7 +6180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6195,7 +6195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6211,7 +6211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6230,7 +6230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6246,7 +6246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6261,7 +6261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6277,7 +6277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6296,7 +6296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6312,7 +6312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6329,7 +6329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6349,7 +6349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6362,7 +6362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6377,7 +6377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6390,7 +6390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6404,7 +6404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6421,23 +6421,6 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/Hexanoyl-ACPs_RXN-9521>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a hexanoyl-[acp]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33055> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" , "Provides Input For Rule. The relation 'an octanoyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; a 3-oxodecanoyl-[acp] + CO<SUB>2</SUB> + acyl-carrier protein' 'null' 'a (3<i>R</i>)-3-hydroxydecanoyl-[acp] + NADP<sup>+</sup> &larr; a 3-oxodecanoyl-[acp] + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -6446,7 +6429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6457,12 +6440,29 @@
           <http://model.geneontology.org/RXN-9528>
 ] .
 
+<http://model.geneontology.org/Hexanoyl-ACPs_RXN-9521>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a hexanoyl-[acp]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33055> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_ACP_RXN-9523_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6487,7 +6487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6503,7 +6503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6522,7 +6522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6540,7 +6540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6551,17 +6551,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000066_reaction_RXN-9531_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
@@ -6570,7 +6559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6581,6 +6570,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9531_BFO_0000066_reaction_RXN-9531_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
@@ -6589,7 +6589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6609,7 +6609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6626,7 +6626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6642,7 +6642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6661,7 +6661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6683,7 +6683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6699,7 +6699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6711,7 +6711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6741,7 +6741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6757,7 +6757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6777,7 +6777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6793,7 +6793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6809,7 +6809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6820,7 +6820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6829,7 +6829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6842,7 +6842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6858,7 +6858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6874,7 +6874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6885,7 +6885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6899,7 +6899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6915,7 +6915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6929,7 +6929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6957,7 +6957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6972,7 +6972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6989,7 +6989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7005,7 +7005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7016,21 +7016,6 @@
           <http://model.geneontology.org/YeastPathways_PWY-5971-1/YeastPathways_PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/YKL182W-MONOMER_RXN-9521_controller>
-        a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fatty acid synthase, beta subunit" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ACP_RXN-9536>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7040,11 +7025,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33026> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/YKL182W-MONOMER_RXN-9521_controller>
+        a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fatty acid synthase, beta subunit" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein32987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -7057,7 +7057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7070,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7085,7 +7085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7098,7 +7098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7123,7 +7123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7131,23 +7131,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_57385_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002413_RXN-9536_SGD_PWY_YeastPathways_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002233_CHEBI_57385_RXN3O-8214_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7158,7 +7158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7176,7 +7176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7192,7 +7192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7211,7 +7211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7231,7 +7231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7244,7 +7244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7255,7 +7255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7269,7 +7269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7288,7 +7288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7304,7 +7304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7315,7 +7315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7329,7 +7329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7348,7 +7348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7368,7 +7368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7383,7 +7383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7396,7 +7396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7407,7 +7407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7422,7 +7422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7435,7 +7435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7449,7 +7449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7468,7 +7468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7484,7 +7484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7499,7 +7499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7512,18 +7512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002413_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7537,7 +7526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7548,6 +7537,17 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9526>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9531_RO_0002413_RXN-9532_SGD_PWY_YeastPathways_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
@@ -7556,7 +7556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7576,7 +7576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7589,7 +7589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7600,7 +7600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7614,7 +7614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7633,7 +7633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7652,7 +7652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7668,7 +7668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7679,7 +7679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7690,7 +7690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7705,7 +7705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7718,7 +7718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7729,7 +7729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7743,7 +7743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7757,7 +7757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7776,7 +7776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7806,7 +7806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7822,7 +7822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7842,7 +7842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7855,7 +7855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7867,7 +7867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7876,6 +7876,25 @@
           <http://model.geneontology.org/RXN-9521> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/Hex-2-enoyl-ACPs_RXN-9520>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9538> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9538_controller>
 ] .
 
 <http://model.geneontology.org/ACP_RXN-9531>
@@ -7887,32 +7906,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33125> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33145> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY_YeastPathways_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9538> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YKL182W-MONOMER_RXN-9538_controller>
-] .
 
 <http://model.geneontology.org/YKL182W-MONOMER_RXN-9538_controller>
         a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7921,7 +7921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7934,7 +7934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7949,7 +7949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7962,7 +7962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7971,7 +7971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7982,7 +7982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7994,7 +7994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8010,7 +8010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -8023,7 +8023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6074-1.ttl
+++ b/models/YeastPathways_PWY-6074-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -183,14 +183,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-319>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -201,13 +198,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75051> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -217,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -349,32 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -465,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,18 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +489,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -532,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -545,9 +528,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_143575>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -557,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,15 +573,12 @@
           <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_18364_RXN66-306_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -619,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -664,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -741,18 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -777,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,11 +814,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +826,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -865,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -895,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,12 +998,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_15379_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1059,7 +1042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1164,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,12 +1172,29 @@
           <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/CHEBI_143575_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_143575> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,22 +1259,11 @@
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1284,7 +1273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1312,7 +1301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,11 +1316,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1328,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_146131_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000050_YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1_SGD_PWY_YeastPathways_PWY-6074-1>
@@ -1347,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1364,7 +1353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1389,23 +1378,23 @@
 <http://purl.obolibrary.org/obo/GO_0102176>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_136486_RXN66-313_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000066_reaction_RXN66-314_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1436,7 +1425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1474,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1485,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1529,7 +1518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1596,11 +1585,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1597,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9824>
+          <http://model.geneontology.org/CHEBI_146130_RXN3O-9824>
 ] .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9822_controller>
@@ -1618,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1631,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1645,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1680,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1699,15 +1688,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN66-314> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
+                <http://model.geneontology.org/CHEBI_146130_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9825> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,7 +1712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1776,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,23 +1803,6 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller>
 ] .
 
-<http://model.geneontology.org/be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
@@ -1839,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1855,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1867,7 +1839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1936,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1963,7 +1935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2009,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2022,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2038,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2057,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2090,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,9 +2073,6 @@
           <http://model.geneontology.org/CHEBI_64925_RXN3O-9823>
 ] .
 
-<http://model.geneontology.org/e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_1949_RXN66-314>
         a       <http://purl.obolibrary.org/obo/CHEBI_1949> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2113,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2126,7 +2095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2173,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,7 +2194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2247,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2274,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2290,7 +2259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2309,7 +2278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2336,11 +2305,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_15379_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2348,19 +2317,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-9826>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2370,7 +2328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2386,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2361,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002413_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2423,7 +2392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2437,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2488,11 +2457,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2500,7 +2469,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_143575_RXN3O-9826>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002411_RXN3O-9822_SGD_PWY_YeastPathways_PWY-6074-1>
@@ -2508,7 +2477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2519,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2530,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2543,7 +2512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2555,11 +2524,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_CHEBI_15377_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2567,7 +2536,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9824>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-306>
@@ -2579,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2595,7 +2564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2632,17 +2601,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/CHEBI_146130_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/CHEBI_146131_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9826> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2655,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2666,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2680,7 +2649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2699,7 +2668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2719,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2732,7 +2701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2740,17 +2709,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002411_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002413_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2765,7 +2734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2784,7 +2753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2804,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2817,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2853,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2866,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2886,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2900,7 +2869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,7 +2915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2965,7 +2934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2981,7 +2950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2992,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3006,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3017,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3031,7 +3000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3051,7 +3020,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/CHEBI_143575_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3061,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3074,7 +3043,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3085,7 +3065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3095,11 +3075,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_146130_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3107,7 +3087,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_146130_RXN3O-9824>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9821>
@@ -3119,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3146,7 +3126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3162,7 +3142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3181,7 +3161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3192,23 +3172,23 @@
           <http://model.geneontology.org/reaction_RXN66-319_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_95c8d239-3c4a-47b6-9bb8-f0166a1acc90_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_58349_RXN66-319_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3222,7 +3202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3238,7 +3218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3252,7 +3232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3272,7 +3252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3285,7 +3265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3299,7 +3279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3319,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,23 +3310,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_13390>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/487c243b-eb8f-486d-9466-1514c77eca2f_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
@@ -3355,7 +3318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,7 +3334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3381,11 +3344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3393,7 +3356,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_143575_RXN3O-9826>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -3407,7 +3370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3425,7 +3388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3438,7 +3401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3452,7 +3415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3468,7 +3431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3479,30 +3442,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-306> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9821>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3512,7 +3467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3523,16 +3478,24 @@
           <http://model.geneontology.org/CHEBI_13392_RXN66-318>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_BFO_0000066_reaction_RXN3O-9825_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" , "Provides Input For Rule. The relation '4,4-dimethylzymosterol + NADP<sup>+</sup> &larr; 4,4-dimethyl-cholesta-8,14,24-trienol + NADPH + H<SUP>+</SUP>' 'null' '4,4-dimethylzymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-4&beta;-methyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002413_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-306> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-9821>
+] .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3556,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,7 +3538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3594,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3608,7 +3571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3624,7 +3587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3639,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3656,9 +3619,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/e0c88a61-bc67-40a5-a265-f5c63aba4ae7_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/CHEBI_146131_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_143575_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3666,7 +3629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3677,17 +3640,6 @@
 <http://purl.obolibrary.org/obo/GO_0050613>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
@@ -3696,7 +3648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3715,7 +3667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3738,7 +3690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3751,11 +3703,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_146130>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3765,7 +3720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3785,7 +3740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3800,7 +3755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3816,7 +3771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3827,16 +3782,22 @@
           <http://model.geneontology.org/YeastPathways_PWY-6074-1/YeastPathways_PWY-6074-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_146131_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_146131> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6074-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3847,7 +3808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3860,7 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3874,7 +3835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3885,12 +3846,23 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-306>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-319_BFO_0000066_reaction_RXN66-319_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3901,7 +3873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3912,7 +3884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3926,7 +3898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3945,7 +3917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,7 +3936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3983,7 +3955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4014,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4027,7 +3999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4038,7 +4010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4048,11 +4020,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4060,7 +4032,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9a566228-0e2c-4a87-ba9e-89552d4ae739_RXN3O-9824>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002233_CHEBI_13392_RXN3O-9821_SGD_PWY_YeastPathways_PWY-6074-1>
@@ -4068,7 +4040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4083,7 +4055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4110,7 +4082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4126,7 +4098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4145,7 +4117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4163,7 +4135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4178,7 +4150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4191,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4202,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4216,7 +4188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4236,7 +4208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4249,7 +4221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4270,7 +4242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4285,7 +4257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4302,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4322,7 +4294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4330,15 +4302,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002413_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4346,7 +4329,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/be0101e4-71ae-43ee-af4e-753a76110aa2_RXN3O-9826>
+          <http://model.geneontology.org/CHEBI_15377_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4357,7 +4340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4377,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4393,7 +4376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4404,7 +4387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4419,7 +4402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4435,7 +4418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4451,7 +4434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4465,7 +4448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4484,7 +4467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4517,7 +4500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4530,7 +4513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4539,7 +4522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4550,17 +4533,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+          "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + NAD(P)H + oxygen &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)H + oxygen &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002411_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002413_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4578,7 +4561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4594,7 +4577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4608,7 +4591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4619,6 +4602,9 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-314>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_146131>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9826>
         a       <http://purl.obolibrary.org/obo/CHEBI_13390> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4628,7 +4614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4641,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4655,7 +4641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4671,28 +4657,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c6258ac8-7298-41b1-a1e4-369cfa90abb1_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4702,7 +4671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4722,7 +4691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4739,7 +4708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4756,7 +4725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4769,7 +4738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4783,7 +4752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4794,7 +4763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4808,7 +4777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4827,7 +4796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4838,6 +4807,17 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_143575_RXN3O-9826_SGD_PWY_YeastPathways_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
@@ -4846,7 +4826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4865,7 +4845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4881,7 +4861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4895,7 +4875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4911,7 +4891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4926,7 +4906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4939,7 +4919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4956,7 +4936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4967,6 +4947,23 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9825>
 ] .
 
+<http://model.geneontology.org/CHEBI_146130_RXN3O-9824>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_146130> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4976,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5005,7 +5002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5021,7 +5018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5041,7 +5038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5057,7 +5054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5076,7 +5073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5092,7 +5089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -5107,7 +5104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5122,11 +5119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_15377_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_146131_RXN3O-9825_SGD_PWY_YeastPathways_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5134,7 +5131,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
+          <http://model.geneontology.org/CHEBI_146131_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/CHEBI_136486_RXN66-313>
@@ -5146,7 +5143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5165,7 +5162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5185,7 +5182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "zymosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5201,7 +5198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5221,7 +5218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5238,7 +5235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5261,7 +5258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6075-1.ttl
+++ b/models/YeastPathways_PWY-6075-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -676,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -869,7 +869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1133,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1160,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1257,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1363,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1543,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1559,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1581,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1670,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1700,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1790,7 +1790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,7 +1809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1836,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1850,7 +1850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1989,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -2016,7 +2016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2032,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -2091,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2111,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6122-1.ttl
+++ b/models/YeastPathways_PWY-6122-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,11 +117,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71919> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/27cfe178-a399-4983-a4f5-602881772aa2_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -130,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -480,28 +497,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004637>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -540,11 +540,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_GART-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,6 +576,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_134413_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -592,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,13 +678,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58359>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_134413>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
@@ -678,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -690,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,18 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +1000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "5-aminoimidazole ribonucleotide biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1206,9 +1215,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58457>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1218,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,14 +1246,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_58457>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_27cfe178-a399-4983-a4f5-602881772aa2_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1251,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1335,11 +1355,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1367,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1358,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1404,13 +1424,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1Protein71851> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1420,7 +1451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,17 +1462,6 @@
           <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_BFO_0000050_YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1_SGD_PWY_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1451,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1497,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1513,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1529,7 +1549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1577,6 +1597,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY-6122-1/YeastPathways_PWY-6122-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/AIRS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004641> ;
@@ -1595,35 +1626,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1BiochemicalReaction71776> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002234_CHEBI_43474_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1634,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1650,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1661,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1676,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,11 +1739,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_27cfe178-a399-4983-a4f5-602881772aa2_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1751,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN>
+          <http://model.geneontology.org/27cfe178-a399-4983-a4f5-602881772aa2_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
@@ -1750,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1761,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1821,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1834,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,7 +1889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,9 +1912,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/CHEBI_134413_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/8ff23b50-6dc1-4bc8-ae45-8b538033bff3_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/27cfe178-a399-4983-a4f5-602881772aa2_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1913,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1926,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1935,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1944,7 +1953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1961,7 +1970,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1974,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2001,7 +2021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2081,7 +2101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2101,7 +2121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2145,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2175,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2191,7 +2211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2202,6 +2222,17 @@
           <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2211,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2219,23 +2250,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_30616_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2257,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2268,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2282,7 +2302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2319,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2346,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2376,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2389,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2404,7 +2424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,28 +2454,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/a115d8b2-1459-4210-a404-ec01c3acd0db_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_GART-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2466,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6123-1.ttl
+++ b/models/YeastPathways_PWY-6123-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -99,9 +99,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/a44a3680-3957-4513-be4d-3d36dc1e101a_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -387,23 +387,6 @@
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004018> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -424,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,27 +454,44 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002333_YMR120C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/a44a3680-3957-4513-be4d-3d36dc1e101a_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72829> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -501,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,12 +635,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002413_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -724,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1050,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,11 +1068,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,8 +1080,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a44a3680-3957-4513-be4d-3d36dc1e101a_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_PWY-6123-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1089,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inosine-5'-phosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1158,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1283,13 +1297,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1Protein72743> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1299,7 +1330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1325,11 +1356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a44a3680-3957-4513-be4d-3d36dc1e101a_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1368,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/a44a3680-3957-4513-be4d-3d36dc1e101a_AICARTRANSFORM-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000070>
@@ -1348,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1359,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1404,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,23 +1446,6 @@
           <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72829> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
@@ -1440,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,6 +1484,17 @@
           <http://model.geneontology.org/YeastPathways_PWY-6123-1/YeastPathways_PWY-6123-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004018> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1477,24 +1502,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1Protein72799> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_766fa3aa-cbbf-4e61-8147-4fdc0933a634_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1504,7 +1518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1559,7 +1573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1589,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1617,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1628,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1640,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1671,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1682,18 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1707,7 +1710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1740,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1781,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1813,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,7 +1832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,11 +1850,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1862,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3544103b-e9fa-43d3-9dd2-5ea6747d87ef_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0043727>
@@ -1874,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1890,7 +1893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1925,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1939,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1980,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +1997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-6125.ttl
+++ b/models/YeastPathways_PWY-6125.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -892,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1377,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,28 +1537,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "XMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29423> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1568,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,6 +1562,23 @@
           <http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "XMP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29423> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_30616_DGDPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1588,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1673,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1774,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1812,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1851,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1867,7 +1867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1883,7 +1883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1927,7 +1927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1980,7 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1993,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2029,7 +2029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2083,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2108,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2134,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,7 +2150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,36 +2159,6 @@
           <http://model.geneontology.org/IMP-DEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_IMP-DEHYDROG-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
@@ -2200,7 +2170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2210,13 +2180,43 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000066_reaction_GDPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2247,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2278,7 +2278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2297,7 +2297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2313,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2343,7 +2343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2357,7 +2357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,7 +2377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2394,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2427,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2438,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2463,7 +2463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2482,7 +2482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2511,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2524,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2538,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2558,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2571,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2582,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2593,7 +2593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2607,7 +2607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2637,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2653,7 +2653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2669,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2680,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2694,7 +2694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2719,7 +2719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2733,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2744,7 +2744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2758,7 +2758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2785,7 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2799,7 +2799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of guanosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2838,7 +2838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2857,7 +2857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2915,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2931,7 +2931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2950,7 +2950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2969,7 +2969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2985,7 +2985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3010,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +3026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3035,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3044,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3055,7 +3055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3066,7 +3066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3080,7 +3080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,7 +3099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3130,7 +3130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3144,7 +3144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3165,7 +3165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3195,7 +3195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3215,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6126-1.ttl
+++ b/models/YeastPathways_PWY-6126-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -501,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,9 +977,47 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENYL-KIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ADPREDUCT-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADPREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DADPKIN-RXN>
+] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004019> ;
@@ -1000,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1008,42 +1046,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' 'null' 'dADP + ATP &rarr; dATP + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADPREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DADPKIN-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1058,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1080,37 +1088,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'AMP + ATP &harr; 2 ADP' 'null' 'dADP + an oxidized thioredoxin + H<sub>2</sub>O &larr; ADP + a reduced thioredoxin' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002413_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6126-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENYL-KIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ADPREDUCT-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002333_YKL067W-MONOMER_DADPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_61404_RXN0-745_SGD_PWY_YeastPathways_PWY-6126-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1404,7 +1404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1503,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1578,7 +1578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of adenosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1805,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1821,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1830,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1844,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1862,7 +1862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,7 +1881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1931,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1948,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +1970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +1989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2018,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2037,7 +2037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2053,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2064,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2089,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,7 +2105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2238,7 +2238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2254,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2268,7 +2268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2301,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2318,7 +2318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2356,7 +2356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2367,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2381,7 +2381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,7 +2400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2422,7 +2422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2438,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2453,7 +2453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2466,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2477,7 +2477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2486,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2500,7 +2500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2519,7 +2519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,7 +2538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-6132.ttl
+++ b/models/YeastPathways_PWY-6132.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lanosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6132" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-6147.ttl
+++ b/models/YeastPathways_PWY-6147.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -266,7 +266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "6-hydroxymethyl-dihydropterin diphosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,7 +860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -921,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,7 +1247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1280,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1485,7 +1485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,7 +1538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1568,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1616,7 +1616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,7 +1638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1727,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1757,7 +1757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6147" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-6482-1.ttl
+++ b/models/YeastPathways_PWY-6482-1.ttl
@@ -2,38 +2,38 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002411_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_80681_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-11373>
+          <http://model.geneontology.org/CHEBI_80681_RXN-11374>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_3a418e41-dc99-440e-8ec7-3249b358e698_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17509_RXN-11371>
+          <http://model.geneontology.org/3a418e41-dc99-440e-8ec7-3249b358e698_RXN-11371>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -41,7 +41,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_18054_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -51,11 +62,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_18054_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +74,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373>
+          <http://model.geneontology.org/CHEBI_18054_RXN-11373>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -71,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +127,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_18054_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -126,19 +148,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11373>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11373>
 ] .
 
 <http://model.geneontology.org/CHEBI_57856_RXN-11373>
@@ -150,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,21 +182,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
+          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -182,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -224,573 +246,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11374>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
-] .
-
-<http://purl.obolibrary.org/obo/ECO_0000363>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_59789_RXN-11371>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAM" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43306> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/RXN-11371>
-        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN-11371> , <http://model.geneontology.org/357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17509_RXN-11371> , <http://model.geneontology.org/CHEBI_15378_RXN-11371> , <http://model.geneontology.org/CHEBI_58031_RXN-11371> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/CPLX-8046_RXN-11371_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/RXN-11370> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1BiochemicalReaction43395> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002411_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/MONOMER-15582_RXN-11374_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "YLR172C" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1Protein43364> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-11370>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "RRT2" ;
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1Complex43521> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
-
-<http://purl.obolibrary.org/obo/CHEBI_456215>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11370>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43349> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/CHEBI_59789_RXN-11374>
-        a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAM" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43306> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
-] .
-
-<http://model.geneontology.org/RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN-11374_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57784_RXN-11370> , <http://model.geneontology.org/CHEBI_59789_RXN-11374> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN-11373> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1BiochemicalReaction43367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57784>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002411_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11373>
-] .
-
-<http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/GO_0017183> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphthamide biosynthesis" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "YeastPathways_PWY-6482-1" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_17509_RXN-11371>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17509> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "<i>S</i>-methyl-5'-thioadenosine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43416> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +282,474 @@
           <http://model.geneontology.org/MONOMER-15582_RXN-11370_controller>
 ] .
 
-<http://model.geneontology.org/357f347a-b8f2-41c1-bb3f-b4bea5fbb2ab_RXN-11371>
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_59789_RXN-11371>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAM" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43306> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_SGD_S000001674_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001674_CPLX-8046_component>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_59789_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/RXN-11371>
+        a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_59789_RXN-11371> , <http://model.geneontology.org/3a418e41-dc99-440e-8ec7-3249b358e698_RXN-11371> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_17509_RXN-11371> , <http://model.geneontology.org/CHEBI_15378_RXN-11371> , <http://model.geneontology.org/CHEBI_58031_RXN-11371> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/CPLX-8046_RXN-11371_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN-11370> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1BiochemicalReaction43395> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_3a418e41-dc99-440e-8ec7-3249b358e698_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/MONOMER-15582_RXN-11374_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004162> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "YLR172C" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1Protein43364> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58031_RXN-11371>
+] .
+
+<http://identifiers.org/sgd/S000000450>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "RRT2" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000000450_CPLX3O-14_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1Complex43521> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
+<http://purl.obolibrary.org/obo/CHEBI_456215>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_18054_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11373> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18054_RXN-11373>
+] .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002333_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11370> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58031_RXN-11371>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_SGD_S000001365_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_18054>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000007587_CPLX-8046_component>
+        a       <http://identifiers.org/sgd/S000007587> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15378_RXN-11374>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43349> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11374> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11374>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
+] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/CHEBI_59789_RXN-11374>
+        a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAM" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43306> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
+] .
+
+<http://model.geneontology.org/RXN-11374>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN-11374_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_57784_RXN-11370> , <http://model.geneontology.org/CHEBI_59789_RXN-11374> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_80681_RXN-11374> , <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN-11373> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1BiochemicalReaction43367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://identifiers.org/sgd/S000004162>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57784>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11373> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
+] .
+
+<http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/GO_0017183> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphthamide biosynthesis" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "YeastPathways_PWY-6482-1" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002333_MONOMER-15582_RXN-11370_controller_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/3a418e41-dc99-440e-8ec7-3249b358e698_RXN-11371>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -829,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,12 +766,81 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_17509_RXN-11371>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17509> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "<i>S</i>-methyl-5'-thioadenosine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43416> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' 'a diphthine-[translation elongation factor 2] + ammonium + ATP &rarr; a diphthamide-[translation elongation factor 2] + AMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002413_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11373> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_80681_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11370> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57784_RXN-11370>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -855,438 +853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58031_RXN-11371>
-] .
-
-<http://model.geneontology.org/6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphthine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/fa4d8b0d-1328-4e5e-a070-b76154e72c56_RXN-11374>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
-] .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN-11373>
-] .
-
-<http://model.geneontology.org/CHEBI_57856_RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43336> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_58031_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58031_RXN-11371>
-] .
-
-<http://model.geneontology.org/04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_28938>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43471> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-11374>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_59789>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000066_reaction_RXN-11371_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
-] .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16692>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43349> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
-] .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_17509>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002411_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57784_RXN-11370>
-] .
-
-<http://purl.obolibrary.org/obo/CHEBI_58031>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002333_MONOMER-15582_RXN-11374_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,12 +887,458 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-11371>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_SGD_S000000450_CPLX3O-14_component_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_80681_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11373> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_80681_RXN-11374>
+] .
+
+<http://model.geneontology.org/CHEBI_57856_RXN-11374>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43336> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11370> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/SGD_S000001365_CPLX-8046_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001365> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_28938>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43471> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11374> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57784_RXN-11370>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_59789>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11370> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-11374>
+] .
+
+<http://identifiers.org/sgd/S000001365>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_SGD_S000007587_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000007587_CPLX-8046_component>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16692>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002413_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43349> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_80681>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
+] .
+
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_17509>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11373> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57856_RXN-11373>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11370> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11370>
+] .
+
+<http://purl.obolibrary.org/obo/CHEBI_58031>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_80681_RXN-11374>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_80681> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11374> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57856_RXN-11374>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11371>
+] .
+
 <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1330,21 +1347,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN>
@@ -1356,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1387,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,33 +1417,33 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374>
+          <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "L-histidien:S-adenosyl-L-methionine 3-amino-3-carboxypropyl transferase" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component> ;
+                <http://model.geneontology.org/SGD_S000001674_CPLX-8046_component> , <http://model.geneontology.org/SGD_S000007587_CPLX-8046_component> , <http://model.geneontology.org/SGD_S000001365_CPLX-8046_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,11 +1456,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16692> ;
@@ -1454,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,54 +1498,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11370> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
-] .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1518,7 +1526,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_SGD_S000007587_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1533,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,42 +1560,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/SGD_S000000450_CPLX3O-14_component>
+        a       <http://identifiers.org/sgd/S000000450> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57784_RXN-11370>
+          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-11374>
+          <http://model.geneontology.org/CHEBI_57856_RXN-11370>
 ] .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11370>
@@ -1588,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,11 +1628,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_SGD_S000001365_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,7 +1640,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX-8046_RXN-11371_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX-8046_component>
+          <http://model.geneontology.org/SGD_S000001365_CPLX-8046_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -1620,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1645,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1707,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373> , <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_18054_RXN-11373> , <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1687,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1697,40 +1725,59 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2] &rarr; a diphthine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002333_CPLX-8046_RXN-11371_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002413_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11371> ;
+          <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
+          <http://model.geneontology.org/RXN-11373>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
           <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-11371> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17509_RXN-11371>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -1738,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1749,9 +1796,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000001674_CPLX-8046_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001674> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1759,11 +1815,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1771,26 +1827,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11373>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000066_reaction_RXN-11370_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11370>
+          <http://model.geneontology.org/reaction_RXN-11370_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -1798,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,19 +1880,8 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-14_component_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000007587>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1846,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1861,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,19 +1933,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_57856_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002233_CHEBI_59789_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN-11374>
+          <http://model.geneontology.org/CHEBI_59789_RXN-11374>
 ] .
 
 <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
@@ -1908,7 +1953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1916,19 +1961,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN-11371>
+          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002233_CHEBI_59789_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -1936,7 +1981,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX-8046_RXN-11371_controller_BFO_0000051_SGD_S000001674_CPLX-8046_component_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_CHEBI_80681_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,21 +2028,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller_BFO_0000051_SGD_S000000450_CPLX3O-14_component_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+          <http://model.geneontology.org/CPLX3O-14_DIPHTINE--AMMONIA-LIGASE-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
+          <http://model.geneontology.org/SGD_S000000450_CPLX3O-14_component>
 ] .
 
 <http://model.geneontology.org/RXN-11373>
@@ -1987,17 +2054,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN-11373> , <http://model.geneontology.org/04063f58-0da1-4aba-9f55-3f0f0d81b16c_RXN-11374> ;
+                <http://model.geneontology.org/CHEBI_80681_RXN-11374> , <http://model.geneontology.org/CHEBI_59789_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> , <http://model.geneontology.org/6a6572f4-e19a-4799-96cf-c14d84354089_RXN-11373> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_18054_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2014,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diphthamide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2038,27 +2105,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" , "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-histidine-[translation elongation factor 2] &rarr; a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-methyl-5'-thioadenosine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a 2-[(3S)-3-amino-3-carboxypropyl]-L-histidine-[translation elongation factor 2] &rarr; a 2-[(3<i>S</i>)-3-carboxy-3-(methylammonio)propyl]-L-histidine-[translation elongation factor 2] + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_BFO_0000066_reaction_RXN-11373_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002413_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11373> ;
+          <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829>
+          <http://model.geneontology.org/RXN-11370>
 ] .
 
 <http://model.geneontology.org/CHEBI_57856_RXN-11370>
@@ -2070,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2082,11 +2149,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2094,7 +2161,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -2102,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2113,18 +2180,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_d0d26045-b12e-4719-b032-09296fe455ef_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002413_RXN-11373_SGD_PWY_YeastPathways_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2134,19 +2201,19 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000050_YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-11374> ;
+          <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY-6482-1/YeastPathways_PWY-6482-1>
+          <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN>
@@ -2158,7 +2225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,11 +2237,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_15378_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2182,7 +2249,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11370> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_RXN-11370>
+          <http://model.geneontology.org/CHEBI_15378_RXN-11370>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002413_RXN-11374_SGD_PWY_YeastPathways_PWY-6482-1>
@@ -2190,29 +2257,49 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_18054_RXN-11373>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18054> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphthine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-11374_BFO_0000066_reaction_RXN-11374_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57784_RXN-11370_SGD_PWY_YeastPathways_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2223,20 +2310,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER-15582_RXN-11370_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004162> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "YLR172C" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2245,13 +2332,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000004162> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "YLR172C" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-6543.ttl
+++ b/models/YeastPathways_PWY-6543.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -33,6 +33,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0046656>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6543" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -42,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,17 +64,6 @@
           <http://model.geneontology.org/ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002233_CHEBI_58406_PABASYN-RXN_SGD_PWY_YeastPathways_PWY-6543>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6543" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6543" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-6614.ttl
+++ b/models/YeastPathways_PWY-6614.ttl
@@ -3,12 +3,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17839> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -19,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -86,11 +103,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +115,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002413_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
@@ -106,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -161,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -256,7 +273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,11 +288,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +300,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008841>
@@ -297,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -417,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,6 +541,23 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/b2af881c-59e3-4593-b0c6-6720a0263177_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
@@ -532,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,28 +598,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004146> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -595,15 +607,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/b2af881c-59e3-4593-b0c6-6720a0263177_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,12 +623,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY-6614>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -647,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -746,42 +758,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -791,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,6 +797,17 @@
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_YeastPathways_PWY-6614/YeastPathways_PWY-6614_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -810,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -940,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrahydrofolate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1033,11 +1039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b2af881c-59e3-4593-b0c6-6720a0263177_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1051,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/93d41722-267d-4c7a-9f1e-8ab352ad23a4_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/b2af881c-59e3-4593-b0c6-6720a0263177_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -1059,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1101,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1206,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1288,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,28 +1327,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/470080ae-4929-4f32-9fbd-524361d51b88_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1352,7 +1341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,3 +1354,14 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b2af881c-59e3-4593-b0c6-6720a0263177_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY-7176.ttl
+++ b/models/YeastPathways_PWY-7176.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UTP and CTP <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1122,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,6 +1307,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_43474_CTPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003883> ;
@@ -1325,24 +1336,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176BiochemicalReaction70545> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002233_CHEBI_58223_RXN-12002_SGD_PWY_YeastPathways_PWY-7176>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1352,7 +1352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1382,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7176" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-7219.ttl
+++ b/models/YeastPathways_PWY-7219.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -222,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-7220-1.ttl
+++ b/models/YeastPathways_PWY-7220-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -854,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1039,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,7 +1294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,8 +1342,16 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-7220-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1353,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1364,23 +1372,15 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-7220-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY-7220-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-7221.ttl
+++ b/models/YeastPathways_PWY-7221.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -702,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1101,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1311,7 +1311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1348,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1478,7 +1478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1503,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1517,7 +1517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,7 +1580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1845,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7221" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY-7222-1.ttl
+++ b/models/YeastPathways_PWY-7222-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -771,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -944,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,6 +953,25 @@
           <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-746> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
@@ -964,32 +983,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7222-1SmallMolecule73104> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY_YeastPathways_PWY-7222-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-746> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15740_RXN0-746>
-] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1382,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1397,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-781.ttl
+++ b/models/YeastPathways_PWY-781.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -67,7 +67,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -184,7 +184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -695,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate assimilation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1260,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1276,7 +1276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1409,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1504,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1603,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1670,7 +1670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-821-1.ttl
+++ b/models/YeastPathways_PWY-821-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,23 +87,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_ADENYLYLSULFKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -114,13 +103,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31038> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,6 +395,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
@@ -403,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,17 +425,6 @@
           <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002333_YJR010W-MONOMER_SULFATE-ADENYLYLTRANS-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -631,9 +631,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/2a7651c2-fac3-4b2c-97f5-f68ec01dd0c5_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/f52d3366-36e1-4c0e-836a-79c1ebe3b606_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of sulfur amino acid biosynthesis (<i>Saccharomyces cerevisiae</i>) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -921,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1009,36 +1009,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1048,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,6 +1029,36 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/S-ADENMETSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_S-ADENMETSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_BFO_0000066_reaction_SULFITE-REDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,34 +1182,12 @@
           <http://model.geneontology.org/CHEBI_58199_ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_BFO_0000066_reaction_1.8.4.8-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1223,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,6 +1212,28 @@
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000050_YeastPathways_PWY-821-1/YeastPathways_PWY-821-1_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YLR180W-MONOMER_S-ADENMETSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1257,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1365,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1379,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1461,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1527,6 +1527,36 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_f52d3366-36e1-4c0e-836a-79c1ebe3b606_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/f52d3366-36e1-4c0e-836a-79c1ebe3b606_RXN3O-22>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1535,7 +1565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,36 +1576,6 @@
           <http://model.geneontology.org/reaction_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_location_lociGO_0005829>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.8.4.8-RXN_RO_0002233_CHEBI_58339_ADENYLYLSULFKIN-RXN_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58343_1.8.4.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58343> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1585,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1631,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1662,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1698,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1805,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1841,7 +1841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1857,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1869,7 +1869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1888,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1913,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1933,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2061,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2077,7 +2077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2116,7 +2116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2154,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,7 +2199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2251,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2265,7 +2265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2317,7 +2317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2333,7 +2333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2347,7 +2347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2363,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2378,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2405,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2418,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,7 +2454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2474,7 +2474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2487,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2504,7 +2504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2550,7 +2550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2566,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2583,7 +2583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,13 +2601,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1Protein31200> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/2a7651c2-fac3-4b2c-97f5-f68ec01dd0c5_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2617,7 +2634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2636,7 +2653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2651,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2693,7 +2710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2709,7 +2726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2725,7 +2742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2740,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2753,7 +2770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2768,7 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2784,7 +2801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2804,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2823,7 +2840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,7 +2859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,7 +2875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2875,7 +2892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2895,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2911,7 +2928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2939,7 +2956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2950,7 +2967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2961,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2986,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3003,7 +3020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3019,7 +3036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,7 +3055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3057,18 +3074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3082,7 +3088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3101,7 +3107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3120,7 +3126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3141,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3160,7 +3166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3176,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3190,7 +3196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3226,7 +3232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3273,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3289,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3300,7 +3306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3315,7 +3321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3331,7 +3337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,7 +3375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3386,7 +3392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3395,7 +3401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3409,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3424,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3440,7 +3446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3472,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3499,7 +3505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3515,7 +3521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3530,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3546,7 +3552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3565,7 +3571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3581,7 +3587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3595,7 +3601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3621,7 +3627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3637,7 +3643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3656,7 +3662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3676,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3693,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3709,7 +3715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3720,7 +3726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3734,7 +3740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3753,7 +3759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3781,7 +3787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3794,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3811,7 +3817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3827,7 +3833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3839,7 +3845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3869,7 +3875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3888,7 +3894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3904,7 +3910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3919,7 +3925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,7 +3952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3962,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3979,7 +3985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4004,7 +4010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4020,7 +4026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4037,7 +4043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4048,12 +4054,23 @@
           <http://model.geneontology.org/CHEBI_16763_CYSTAGLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_2a7651c2-fac3-4b2c-97f5-f68ec01dd0c5_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_RO_0002233_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4064,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4075,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4086,7 +4103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4100,7 +4117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4116,7 +4133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4127,7 +4144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4139,7 +4156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4159,7 +4176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4172,7 +4189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4183,7 +4200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4197,7 +4214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4216,7 +4233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4236,7 +4253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4252,7 +4269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4271,7 +4288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4293,7 +4310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4304,7 +4321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4319,7 +4336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4335,7 +4352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4354,7 +4371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4370,7 +4387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4384,7 +4401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4407,7 +4424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4437,7 +4454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4453,7 +4470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4472,7 +4489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4488,7 +4505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4499,7 +4516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4513,7 +4530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4523,17 +4540,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -4546,7 +4552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4566,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4582,7 +4588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4598,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4609,7 +4615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4621,7 +4627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4637,7 +4643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4651,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4661,11 +4667,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_2a7651c2-fac3-4b2c-97f5-f68ec01dd0c5_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4673,7 +4679,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22>
+          <http://model.geneontology.org/2a7651c2-fac3-4b2c-97f5-f68ec01dd0c5_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4684,7 +4690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4706,7 +4712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4717,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4729,7 +4735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4752,7 +4758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4771,7 +4777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4785,7 +4791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4804,7 +4810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4820,7 +4826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4835,7 +4841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4848,7 +4854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4862,7 +4868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4881,7 +4887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4904,7 +4910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4920,7 +4926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4934,7 +4940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4954,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4969,7 +4975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4982,7 +4988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5007,7 +5013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5023,7 +5029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5039,7 +5045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5050,7 +5056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5064,7 +5070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5089,7 +5095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5109,7 +5115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5126,7 +5132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5142,7 +5148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5156,7 +5162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5175,7 +5181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5194,7 +5200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5209,7 +5215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5225,7 +5231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5244,7 +5250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5260,7 +5266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5271,7 +5277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5286,7 +5292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5299,7 +5305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5313,7 +5319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5329,7 +5335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5338,7 +5344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5349,7 +5355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5363,7 +5369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5382,7 +5388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5412,7 +5418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5425,7 +5431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5437,7 +5443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5456,7 +5462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5478,7 +5484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5493,7 +5499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5513,7 +5519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5529,7 +5535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5540,7 +5546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5549,29 +5555,12 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/51d31dc1-87e7-4a90-bcb9-bfc72b411a7f_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5582,7 +5571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5593,7 +5582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5604,7 +5593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5616,7 +5605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5638,7 +5627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5657,7 +5646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5673,7 +5662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5684,7 +5673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5695,7 +5684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5712,7 +5701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5742,7 +5731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5755,7 +5744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5769,7 +5758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5789,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5805,7 +5794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5824,7 +5813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5843,7 +5832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5854,7 +5843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5866,7 +5855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5882,11 +5871,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/f52d3366-36e1-4c0e-836a-79c1ebe3b606_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5896,7 +5902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,7 +5921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5934,7 +5940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5950,7 +5956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5964,7 +5970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5980,7 +5986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5998,7 +6004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6011,7 +6017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6022,7 +6028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6040,7 +6046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6056,7 +6062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6072,7 +6078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6090,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6105,7 +6111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6121,7 +6127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6137,7 +6143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6148,7 +6154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6157,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6168,7 +6174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6183,7 +6189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6196,7 +6202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6208,29 +6214,12 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/59488dab-f557-4b04-bf29-2cfd2318665d_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6245,7 +6234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6261,7 +6250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6277,7 +6266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6292,7 +6281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6307,7 +6296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6322,7 +6311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6341,7 +6330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6360,7 +6349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6376,7 +6365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6394,7 +6383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6407,7 +6396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6424,7 +6413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6443,7 +6432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6462,7 +6451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6478,7 +6467,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_f52d3366-36e1-4c0e-836a-79c1ebe3b606_RXN3O-22_SGD_PWY_YeastPathways_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6489,7 +6489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6503,7 +6503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6522,7 +6522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6538,7 +6538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6551,7 +6551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6567,7 +6567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6586,7 +6586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6605,7 +6605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6628,7 +6628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6641,7 +6641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6655,7 +6655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6675,7 +6675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6694,7 +6694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6712,7 +6712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6725,7 +6725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6739,7 +6739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6764,7 +6764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY-901.ttl
+++ b/models/YeastPathways_PWY-901.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,15 +174,6 @@
           <http://model.geneontology.org/CHEBI_57925_GLYOXII-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GLYOXII-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY-901/YeastPathways_PWY-901>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0051596> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -192,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -208,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,6 +209,15 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57925_GLYOXI-RXN>
 ] .
+
+<http://model.geneontology.org/reaction_GLYOXII-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,14 +280,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -297,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,12 +305,15 @@
           <http://model.geneontology.org/CHEBI_16004_GLYOXII-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_GLYOXII-RXN_RO_0002233_CHEBI_57474_GLYOXI-RXN_SGD_PWY_YeastPathways_PWY-901>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -666,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methylglyoxal catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY-922.ttl
+++ b/models/YeastPathways_PWY-922.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -153,6 +153,17 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
@@ -161,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,17 +183,6 @@
           <http://model.geneontology.org/CHEBI_57287_1.1.1.34-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,20 +297,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_36464>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004421>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -318,13 +304,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922Protein74835> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002333_YPL117C-MONOMER_IPPISOM-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004421>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -898,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -913,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -979,7 +979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1040,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,18 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY-922" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,6 +1216,17 @@
           <http://model.geneontology.org/CHEBI_36464_1.1.1.34-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002333_YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY-922>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY-922" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
@@ -1235,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,7 +1365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1426,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1486,7 +1486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1592,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1674,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1840,7 +1840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1876,7 +1876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1892,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1906,7 +1906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2037,7 +2037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2089,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2103,7 +2103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,7 +2119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2189,7 +2189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,7 +2208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2263,7 +2263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2282,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,7 +2298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2312,7 +2312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2348,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2363,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2385,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2394,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2408,7 +2408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2427,7 +2427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2443,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2479,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2492,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2507,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2524,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2540,7 +2540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2559,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2568,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2583,7 +2583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,7 +2602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2624,7 +2624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2672,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2692,7 +2692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2712,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2728,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2751,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2775,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2784,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2795,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY-922" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY0-162.ttl
+++ b/models/YeastPathways_PWY0-162.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -490,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1032,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of pyrimidine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,7 +1422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1612,7 +1612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1645,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,7 +1695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1721,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,7 +1779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1840,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1856,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1886,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1924,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1952,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1990,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,7 +2006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2019,7 +2019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2035,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,7 +2054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2085,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2098,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2112,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2134,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2146,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,7 +2184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2200,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2228,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2244,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2255,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,7 +2305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2336,7 +2336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2352,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2369,7 +2369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2396,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2419,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2436,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2463,7 +2463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2479,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2491,7 +2491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2507,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2558,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2585,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2601,7 +2601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2620,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2636,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2647,7 +2647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2664,7 +2664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2680,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2693,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2709,7 +2709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2728,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2742,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2797,7 +2797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2816,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2831,7 +2831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,7 +2847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2881,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2919,7 +2919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2939,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2952,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2966,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2979,7 +2979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2995,7 +2995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3014,7 +3014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3030,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3045,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3061,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3077,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3090,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3107,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3123,7 +3123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3159,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3175,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3189,7 +3189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,7 +3208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3222,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3233,7 +3233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3244,7 +3244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3258,7 +3258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3272,7 +3272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3288,7 +3288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3303,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3319,7 +3319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3335,7 +3335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3358,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3377,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3397,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3410,7 +3410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3421,7 +3421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3435,7 +3435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3454,7 +3454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3473,7 +3473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3501,7 +3501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3520,7 +3520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3529,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3540,7 +3540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3554,7 +3554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3568,7 +3568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3587,7 +3587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,7 +3603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3614,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3625,7 +3625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3648,7 +3648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3664,7 +3664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3687,7 +3687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3703,7 +3703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3714,7 +3714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3725,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3736,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3747,7 +3747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3761,7 +3761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,7 +3777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3788,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3802,7 +3802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3816,7 +3816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3832,7 +3832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3846,7 +3846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3866,7 +3866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3879,7 +3879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3893,7 +3893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3915,7 +3915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,7 +3931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3968,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY0-662.ttl
+++ b/models/YeastPathways_PWY0-662.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "PRPP biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY0-662" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-0.ttl
+++ b/models/YeastPathways_PWY3O-0.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -462,9 +462,6 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_57579>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN-14812>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -481,13 +478,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-0BiochemicalReaction26679> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57579>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YFR053C-MONOMER_RXN3O-9790_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001949> ;
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fructose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-1.ttl
+++ b/models/YeastPathways_PWY3O-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of purines and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -933,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1017,7 +1017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1170,7 +1170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1243,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1354,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1397,7 +1397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1427,7 +1427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1504,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1541,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1557,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1571,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,7 +1590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1650,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1719,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +1739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1770,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1827,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1914,13 +1914,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1SmallMolecule47408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1930,7 +1939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,15 +1950,6 @@
           <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GUANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/MONOMER3O-12_GUANINE-DEAMINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000002397> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +1973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2006,7 +2006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2069,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2100,7 +2100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,7 +2119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2169,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2185,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2200,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2216,7 +2216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2258,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2274,7 +2274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2293,7 +2293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2312,7 +2312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2348,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2371,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2398,7 +2398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,7 +2417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2436,7 +2436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2452,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2467,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2501,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2517,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2570,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,7 +2589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2603,7 +2603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2625,7 +2625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2659,7 +2659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2692,7 +2692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2711,7 +2711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2731,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2747,7 +2747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2766,7 +2766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2782,7 +2782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2793,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2804,7 +2804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2815,7 +2815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2829,7 +2829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2848,7 +2848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2867,7 +2867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2886,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2917,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2937,7 +2937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2950,7 +2950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2961,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2970,7 +2970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2982,7 +2982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,7 +3001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3031,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3047,7 +3047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3063,7 +3063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3074,7 +3074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3086,7 +3086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3102,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3113,7 +3113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3128,7 +3128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3145,7 +3145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3160,7 +3160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3173,7 +3173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3190,7 +3190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3212,7 +3212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3231,7 +3231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3279,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3299,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3315,7 +3315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3331,7 +3331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3354,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3370,7 +3370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3386,7 +3386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3399,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3418,7 +3418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3434,7 +3434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3448,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3462,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3500,7 +3500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3512,7 +3512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-10.ttl
+++ b/models/YeastPathways_PWY3O-10.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,7 +885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1087,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,7 +1154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1260,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1384,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1395,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,7 +1464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1498,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1579,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1650,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,7 +1663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1710,7 +1710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1744,7 +1744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1771,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1858,7 +1858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1874,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1888,7 +1888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,7 +1907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1944,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1977,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2027,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2082,7 +2082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2098,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2133,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2160,7 +2160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,7 +2179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2193,7 +2193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2248,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2262,7 +2262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2278,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2296,7 +2296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2312,7 +2312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,7 +2331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2380,7 +2380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2396,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid biosynthesis, initial steps - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2424,7 +2424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2437,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2471,7 +2471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2516,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2531,7 +2531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2547,7 +2547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2569,7 +2569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2588,7 +2588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2604,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2613,7 +2613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2690,7 +2690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2718,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2737,7 +2737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2753,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2775,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2786,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2828,7 +2828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2848,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2864,7 +2864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,7 +2883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,7 +2911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2924,7 +2924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2937,7 +2937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2950,7 +2950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2961,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-10" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-103.ttl
+++ b/models/YeastPathways_PWY3O-103.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -42,11 +42,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17962>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -62,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +90,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,28 +119,8 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_37563>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -151,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,13 +195,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,12 +212,12 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -353,11 +336,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +348,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1f9d521b-d1a4-4309-bdb7-c5d7f9c5e88e_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -382,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -419,6 +402,23 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17962> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -426,11 +426,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_17962_CDPDIGLYSYN-RXN_SGD_PWY_YeastPathways_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +438,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_CDPDIGLYSYN-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-103>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "CDP-diacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-103" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-1109.ttl
+++ b/models/YeastPathways_PWY3O-1109.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -150,7 +150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-hydroxybenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -933,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1005,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1354,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,7 +1465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1630,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1650,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1664,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1705,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,7 +1780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,7 +1799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1843,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1932,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1945,7 +1945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1967,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2009,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2062,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,7 +2095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2125,7 +2125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2141,7 +2141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2155,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2166,7 +2166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2196,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2210,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2230,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2257,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2287,7 +2287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2318,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2329,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2344,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-114.ttl
+++ b/models/YeastPathways_PWY3O-114.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,11 +82,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62466> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/c5eedde6-85c9-450d-bd0c-5c260bac1ec9_RXN-6601>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -95,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutathione metabolism (truncated &gamma;-glutamyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,23 +224,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_c5eedde6-85c9-450d-bd0c-5c260bac1ec9_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -335,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -411,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -669,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -840,13 +851,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" , "Provides Input For Rule. The relation 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+          "Provides Input For Rule. The relation 'L-cysteine + L-glutamate + ATP &rarr; &gamma;-L-glutamyl-L-cysteine + ADP + phosphate + H<SUP>+</SUP>' 'null' 'glycine + &gamma;-L-glutamyl-L-cysteine + ATP &rarr; glutathione + ADP + phosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -967,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -992,18 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1081,7 +1081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,7 +1131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-SYN-RXN> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
+                <http://model.geneontology.org/c5eedde6-85c9-450d-bd0c-5c260bac1ec9_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1330,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1343,7 +1343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1388,7 +1388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1415,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1439,11 +1439,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_c5eedde6-85c9-450d-bd0c-5c260bac1ec9_RXN-6601_SGD_PWY_YeastPathways_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1451,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fd717b5e-f0ad-4abe-acad-d1e1a7263676_RXN-6601>
+          <http://model.geneontology.org/c5eedde6-85c9-450d-bd0c-5c260bac1ec9_RXN-6601>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1462,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1498,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1579,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1593,7 +1593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1677,7 +1677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1688,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1699,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1749,7 +1749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1778,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1830,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-114" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-123.ttl
+++ b/models/YeastPathways_PWY3O-123.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -18,13 +18,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl phosphate D-mannose biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_15809_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MANNPISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004476> ;
@@ -45,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -220,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,11 +365,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +377,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.83-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN>
+          <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
@@ -378,17 +389,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58189> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,22 +406,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/2.4.1.83-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004582> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -434,13 +431,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16214_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_57527_MANNPGUANYLTRANGDP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> , <http://model.geneontology.org/f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN> ;
+                <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_15809_2.4.1.83-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR183W-MONOMER_2.4.1.83-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,6 +617,23 @@
           <http://model.geneontology.org/CHEBI_15378_MANNPGUANYLTRANGDP-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15809_2.4.1.83-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15809> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16214>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -627,11 +641,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_58189_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_CHEBI_15809_2.4.1.83-RXN_SGD_PWY_YeastPathways_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +653,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.83-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN>
+          <http://model.geneontology.org/CHEBI_15809_2.4.1.83-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -653,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -665,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -718,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -831,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1059,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1178,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,29 +1230,12 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/f8ffea68-6992-44d0-a655-a989defc8e1e_2.4.1.83-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PHOSMANMUT-RXN_RO_0002333_YFL045C-MONOMER_PHOSMANMUT-RXN_controller_SGD_PWY_YeastPathways_PWY3O-123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,12 +1282,15 @@
           <http://model.geneontology.org/CHEBI_43474_MANNPGUANYLTRANGDP-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15809>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY_YeastPathways_PWY3O-123>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-13.ttl
+++ b/models/YeastPathways_PWY3O-13.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,7 +112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -708,7 +708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -794,7 +794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1480,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1559,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1588,7 +1588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1678,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1728,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1780,7 +1780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1843,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1880,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1908,7 +1908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1943,7 +1943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutamate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2048,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2061,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-15.ttl
+++ b/models/YeastPathways_PWY3O-15.ttl
@@ -8,7 +8,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-15" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-1565.ttl
+++ b/models/YeastPathways_PWY3O-1565.ttl
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl glucosyl phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-17.ttl
+++ b/models/YeastPathways_PWY3O-17.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -174,13 +174,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69169> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000006179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -190,7 +193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,15 +204,12 @@
           <http://model.geneontology.org/CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000006179>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_15378_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,18 +346,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,12 +382,12 @@
           <http://model.geneontology.org/THI-P-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_OHMETPYRKIN-RXN_RO_0002233_CHEBI_30616_OHMETPYRKIN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXNQT-4301_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -567,23 +567,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-82_PYRIMSYN3-RXN_controller_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002333_MONOMER3O-9145_RXN3O-9804_controller_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,17 +820,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-10511_RXN3O-401_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -843,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,6 +842,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58354_OHMETPYRKIN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/OHMETPYRKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -873,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,12 +881,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-10511_RXN3O-401_BFO_0000051_SGD_S000003376_CPLX3O-10511_component_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_CPLX3O-9180_THI-P-SYN-RXN_controller_BFO_0000051_SGD_S000006135_CPLX3O-9180_component_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,18 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1243,7 +1232,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002233_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1354,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1559,7 +1559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1570,8 +1570,16 @@
           <http://model.geneontology.org/CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0009228>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1581,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,6 +1600,9 @@
           <http://model.geneontology.org/CHEBI_139151_RXN3O-401>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0009228>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
@@ -1600,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,23 +1622,12 @@
           <http://model.geneontology.org/CHEBI_17154_RXN3O-401>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000066_reaction_THI-P-SYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002233_CPLX3O-10511_RXN3O-401_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1659,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,7 +1675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1715,7 +1715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1786,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thiamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1814,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1895,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1972,7 +1972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,7 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2098,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,7 +2117,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58354_OHMETPYRKIN-RXN> , <http://model.geneontology.org/CHEBI_30616_PYRIMSYN3-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN> , <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN> , <http://model.geneontology.org/CHEBI_57841_PYRIMSYN3-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-82_PYRIMSYN3-RXN_controller> , <http://model.geneontology.org/CPLX3O-80_PYRIMSYN3-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2125,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2157,7 +2157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2202,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2230,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2246,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2293,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2304,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2318,7 +2318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2338,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2382,7 +2382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2417,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2428,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2441,7 +2441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2457,7 +2457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2479,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2511,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,7 +2538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2582,7 +2582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2598,18 +2598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2623,7 +2612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,6 +2623,17 @@
           <http://model.geneontology.org/CPLX3O-10511_RXN3O-401>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_37575_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
@@ -2642,7 +2642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2689,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2700,7 +2700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2718,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2737,7 +2737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,7 +2756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2775,7 +2775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2794,7 +2794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2830,23 +2830,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXNQT-4301_RO_0002234_CHEBI_16526_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002413_RXNQT-4301_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2857,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2871,16 +2871,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2894,7 +2894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,23 +2905,23 @@
           <http://model.geneontology.org/CHEBI_37575_THI-P-SYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_BFO_0000066_reaction_THIAMIN-PYROPHOSPHOKINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002234_CHEBI_15378_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2935,7 +2935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2946,12 +2946,12 @@
           <http://model.geneontology.org/CHEBI_15377_RXNQT-4191>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_BFO_0000050_YeastPathways_PWY3O-17/YeastPathways_PWY3O-17_SGD_PWY_YeastPathways_PWY3O-17>
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_BFO_0000066_reaction_RXNQT-4191_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2965,7 +2965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2984,7 +2984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3000,7 +3000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3011,7 +3011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3025,7 +3025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3044,7 +3044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3060,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3074,7 +3074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3090,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3104,7 +3104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3120,7 +3120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3142,7 +3142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3158,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3177,7 +3177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3196,7 +3196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3212,7 +3212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3221,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3235,7 +3235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3251,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3264,13 +3264,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule68874> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3280,7 +3291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3291,23 +3302,12 @@
           <http://model.geneontology.org/CHEBI_43474_RXNQT-4191>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THI-P-SYN-RXN_RO_0002234_CHEBI_29888_THI-P-SYN-RXN_SGD_PWY_YeastPathways_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_57841_PYRIMSYN3-RXN_SGD_PWY_YeastPathways_PWY3O-17>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3322,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3365,7 +3365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,7 +3381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3392,7 +3392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3403,7 +3403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3418,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3435,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3451,7 +3451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3470,7 +3470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3488,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3504,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3518,7 +3518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3534,7 +3534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3548,7 +3548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3570,7 +3570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3596,7 +3596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3613,7 +3613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3626,7 +3626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3640,7 +3640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-1743.ttl
+++ b/models/YeastPathways_PWY3O-1743.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mannose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-1801.ttl
+++ b/models/YeastPathways_PWY3O-1801.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitoleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -708,7 +708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -782,30 +782,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY_YeastPathways_PWY3O-1801>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-1801" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-10662_RO_0002234_CHEBI_15378_RXN-10662_SGD_PWY_YeastPathways_PWY3O-1801>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-1801" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10664_RO_0002333_YGL055W-MONOMER_RXN-10664_controller_SGD_PWY_YeastPathways_PWY3O-1801>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-1874.ttl
+++ b/models/YeastPathways_PWY3O-1874.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -170,7 +170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-188.ttl
+++ b/models/YeastPathways_PWY3O-188.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -87,23 +87,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" , "Provides Input For Rule. The relation 'reduced cytochrome c + oxygen &rarr; oxidized cytochrome c + H<sub>2</sub>O' 'null' '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002411_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9794> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,6 +140,17 @@
           <http://model.geneontology.org/CHEBI_57540_RXN3O-165>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_15991_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
@@ -148,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -173,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -182,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -202,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -212,19 +223,33 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/CHEBI_15991_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15991> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "oxidized cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000004028_CPLX3O-117_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004028> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_30031>
@@ -238,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -247,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -262,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -291,11 +316,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_16928_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +328,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
+          <http://model.geneontology.org/CHEBI_16928_RXN3O-168>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -314,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,17 +415,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> , <http://model.geneontology.org/e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_16928_RXN3O-168> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
+                <http://model.geneontology.org/CHEBI_15991_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-168> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,23 +502,23 @@
 <http://identifiers.org/sgd/S000006395>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000003964_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -524,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,11 +609,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16928>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57540_RXN3O-165>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -599,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -624,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -637,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aerobic respiration, electron transport chain - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -647,21 +675,21 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002411_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-9794>
+          <http://model.geneontology.org/RXN3O-165>
 ] .
 
 <http://identifiers.org/sgd/S000007283>
@@ -675,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -706,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -765,11 +793,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15991_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +805,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9794> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794>
+          <http://model.geneontology.org/CHEBI_15991_RXN3O-9794>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -791,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -891,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,11 +934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_15991_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +946,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN>
+          <http://model.geneontology.org/CHEBI_15991_RXN3O-9794>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -929,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -954,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1034,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1091,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1110,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,36 +1198,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "reduced cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1248,11 +1259,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_52971_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,7 +1271,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168>
+          <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
 ] .
 
 <http://identifiers.org/sgd/S000007260>
@@ -1277,7 +1288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1305,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1317,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1356,32 +1367,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188BiochemicalReaction17360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -1392,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,12 +1392,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_16928_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16928_RXN3O-168>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-168_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,6 +1444,9 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
@@ -1441,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,6 +1465,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000007270_CPLX3O-109_component>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003964>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1464,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,21 +1502,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1519,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1533,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,14 +1571,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1566,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1595,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1638,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1649,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1658,15 +1677,12 @@
 <http://identifiers.org/sgd/S000001631>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000002937>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,29 +1717,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "oxidized cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://identifiers.org/sgd/S000002937>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9794_BFO_0000050_YeastPathways_PWY3O-188/YeastPathways_PWY3O-188_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1748,13 +1750,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'NADH + ubiquinone-<i>6</i> &rarr; NAD<sup>+</sup> + ubiquinol-6' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+          "Provides Input For Rule. The relation '2 oxidized cytochrome c + ubiquinol-6 &rarr; 2 reduced cytochrome c + ubiquinone-<i>6</i>' 'null' 'reduced cytochrome c + oxygen &rarr; oxidized cytochrome c + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-165_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002413_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1764,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-165>
+          <http://model.geneontology.org/RXN3O-9794>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1773,7 +1775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1825,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1834,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1884,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,7 +1905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1919,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1930,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1955,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,11 +1989,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY_YeastPathways_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,7 +2001,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794>
+          <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-109_RXN3O-168_controller_BFO_0000051_SGD_S000003702_CPLX3O-109_component_SGD_PWY_YeastPathways_PWY3O-188>
@@ -2007,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2018,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2029,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2043,7 +2045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2059,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2073,7 +2075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2084,12 +2086,12 @@
           <http://model.geneontology.org/SGD_S000000141_CPLX3O-109_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002411_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2107,19 +2109,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794> ;
+                <http://model.geneontology.org/CHEBI_52970_SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/CHEBI_15991_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_52971_RXN3O-168> , <http://model.geneontology.org/dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_16928_RXN3O-168> , <http://model.geneontology.org/CHEBI_52971_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/RXN3O-165> ;
+                <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN> , <http://model.geneontology.org/RXN3O-9794> , <http://model.geneontology.org/RXN3O-165> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2138,7 +2138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2157,7 +2157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2173,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2185,7 +2185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,17 +2199,6 @@
 <http://identifiers.org/sgd/S000003415>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_6ec260f6-7a26-4c0d-8757-473a4913a040_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002585>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2222,13 +2211,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17417> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_CHEBI_15991_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2238,7 +2238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2254,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2265,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,17 +2290,6 @@
           <http://model.geneontology.org/SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
@@ -2309,7 +2298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2337,22 +2326,39 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002411_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://identifiers.org/sgd/S000004387>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_16928_RXN3O-168>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16928> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "reduced cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2362,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2373,7 +2379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2388,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2397,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2408,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2417,7 +2423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2428,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2440,7 +2446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2459,7 +2465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2475,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2487,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2503,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2514,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2522,9 +2528,6 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003702>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29806>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2535,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2546,21 +2549,15 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
 ] .
 
-<http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005591> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_BFO_0000051_SGD_S000002585_CPLX3O-742_component_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2585,14 +2582,12 @@
           <http://model.geneontology.org/CHEBI_52971_RXN3O-168>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_e214ca17-aa73-49b3-95c2-9e1c04266f60_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005591> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-188" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2604,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2623,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2634,18 +2629,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000007283_CPLX3O-117_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000007283> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2654,7 +2640,27 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000007283_CPLX3O-117_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000007283> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_CHEBI_16928_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2663,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2675,7 +2681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2686,14 +2692,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001624>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -2704,13 +2707,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188Complex17298> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
+
+<http://identifiers.org/sgd/S000001624>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003155>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2723,7 +2729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,17 +2740,6 @@
           <http://model.geneontology.org/CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_d27b514c-4676-4735-9db6-e034f6124fce_RXN3O-9794_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
@@ -2753,7 +2748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2773,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2786,7 +2781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2800,7 +2795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2811,12 +2806,23 @@
           <http://model.geneontology.org/SGD_S000007260_CPLX3O-117_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_16928_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002333_CPLX3O-117_RXN3O-9794_controller_SGD_PWY_YeastPathways_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2827,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2836,18 +2842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_dfce4873-fa27-4563-83f2-e7f05b7b63c1_RXN3O-168_SGD_PWY_YeastPathways_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-188" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-19.ttl
+++ b/models/YeastPathways_PWY3O-19.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -241,18 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_PWY_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,6 +266,17 @@
           <http://model.geneontology.org/RXN3O-102>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002333_YGR255C-MONOMER_RXN3O-58_controller_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,18 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -403,6 +392,17 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ubiquinol-6 biosynthesis from 4-hydroxybenzoate (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -894,7 +894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1220,7 +1220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1269,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1311,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1401,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1417,7 +1417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1485,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,18 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1634,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,6 +1634,17 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-12>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002234_CHEBI_61472_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59789_2.1.1.114-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1654,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1670,7 +1670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,7 +1686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1717,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1877,7 +1877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,7 +1915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1952,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1980,7 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2023,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2040,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2084,7 +2084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2093,6 +2093,36 @@
           <http://model.geneontology.org/2.1.1.114-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_59789_2.1.1.114-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-58> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.1.1.114-RXN>
 ] .
 
 <http://model.geneontology.org/RXN3O-102>
@@ -2112,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2122,43 +2152,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hexaprenyl-4-hydroxybenzoate + 2 a reduced ferredoxin [iron-sulfur] cluster + oxygen + 2 H<SUP>+</SUP> &rarr; 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + 2 an oxidized ferredoxin [iron-sulfur] cluster + H<sub>2</sub>O' 'null' '<i>S</i>-adenosyl-L-methionine + 3,4-dihydroxy-5-<i>all-trans</i>-hexaprenylbenzoate &rarr; <i>S</i>-adenosyl-L-homocysteine + 3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-58> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.1.1.114-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002333_YGR255C-MONOMER_RXN3O-12_controller_SGD_PWY_YeastPathways_PWY3O-19> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2191,7 +2191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2222,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,7 +2262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,25 +2271,6 @@
           <http://model.geneontology.org/RXN3O-75> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-19/YeastPathways_PWY3O-19>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-54> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_61473_RXN3O-54>
 ] .
 
 <http://model.geneontology.org/RXN3O-73>
@@ -2309,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2317,12 +2298,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_61473_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-54> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_61473_RXN3O-54>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-54_RO_0002234_CHEBI_15378_RXN3O-54_SGD_PWY_YeastPathways_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2336,7 +2336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2367,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2378,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2389,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2400,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2426,7 +2426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2466,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2501,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2513,7 +2513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2529,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2554,7 +2554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2570,7 +2570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2600,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2618,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2631,7 +2631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2654,7 +2654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2670,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2684,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2717,7 +2717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2731,7 +2731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2766,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2777,7 +2777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2795,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2812,7 +2812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2828,7 +2828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2850,7 +2850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2869,7 +2869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2888,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2906,7 +2906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2945,7 +2945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2959,7 +2959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2978,7 +2978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2994,7 +2994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3008,7 +3008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3027,7 +3027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3052,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3061,7 +3061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3075,7 +3075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3094,7 +3094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3113,7 +3113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3129,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3142,7 +3142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3155,7 +3155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,7 +3187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3200,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3215,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3231,7 +3231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3270,7 +3270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3283,7 +3283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3308,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3324,7 +3324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3340,7 +3340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3353,7 +3353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3369,7 +3369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-2.ttl
+++ b/models/YeastPathways_PWY3O-2.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17,40 +17,25 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-5781>
 ] .
 
-<http://model.geneontology.org/CHEBI_57856_RXN3O-349>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAH" ;
+<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31991> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -61,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,16 +54,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57856_RXN3O-349>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31991> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -88,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -115,18 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,6 +140,17 @@
           <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002413_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,24 +219,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32004> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57597> ;
@@ -247,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,11 +432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +444,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -466,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,9 +516,6 @@
           <http://model.geneontology.org/YER026C-MONOMER_PHOSPHASERSYN-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003402> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -537,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +585,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17962_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -607,6 +604,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0004306>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN4FS-2>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -617,7 +625,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -625,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,32 +641,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -666,7 +657,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002333_YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
@@ -674,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,11 +782,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +794,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN>
@@ -815,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -850,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -880,26 +871,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32489> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003239> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphoethanolamine cytidylyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32282> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -908,11 +884,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003239> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphoethanolamine cytidylyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32282> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -923,16 +914,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31977> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -942,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,18 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1019,11 +996,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_37393>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1032,11 +1012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1024,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
@@ -1052,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1064,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1078,6 +1058,17 @@
 <http://identifiers.org/sgd/S000003389>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
@@ -1086,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1126,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1162,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1170,22 +1161,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004608>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://purl.obolibrary.org/obo/GO_0004608>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1195,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1261,11 +1260,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1272,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_17962_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHOLINE-KINASE-RXN>
@@ -1295,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,7 +1311,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1322,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,34 +1359,26 @@
           <http://model.geneontology.org/CHEBI_456216_CHOLINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.71-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-349>
-] .
 
 <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_16110_RXN-5781_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1395,13 +1386,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.71-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-349>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,7 +1419,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59789_RXN4FS-2>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1422,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1448,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1510,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1526,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,18 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1578,11 +1577,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,7 +1589,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1601,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1657,11 +1656,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,48 +1690,12 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN>
-] .
-
-<http://model.geneontology.org/90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1728,11 +1710,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32151> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_17962_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17962> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1748,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1830,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1854,11 +1853,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_59789_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1865,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57880>
@@ -1877,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1892,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1909,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1930,17 +1929,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+          "Provides Input For Rule. The relation 'a CDP-diacylglycerol + <i>sn</i>-glycerol 3-phosphate &rarr; CMP + 1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<SUP>+</SUP>' 'null' '1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate + H<sub>2</sub>O &rarr; an L-1-phosphatidyl-<i>sn</i>-glycerol + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002413_PGPPHOSPHA-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1955,7 +1954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1991,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2002,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2016,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,11 +2030,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_CHEBI_59789_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,7 +2042,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN>
+          <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2054,7 +2053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,23 +2064,6 @@
           <http://model.geneontology.org/CHEBI_16110_RXN3O-349>
 ] .
 
-<http://model.geneontology.org/e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YLR133W-MONOMER_CHOLINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004123> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2089,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,7 +2087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2133,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2174,7 +2156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,11 +2174,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2204,7 +2186,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
@@ -2212,7 +2194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2226,7 +2208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2271,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2318,15 +2300,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/2.1.1.71-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2342,7 +2324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2358,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2369,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2380,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2391,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2404,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,7 +2405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2445,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2456,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2471,7 +2453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2483,11 +2465,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2495,7 +2477,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
@@ -2503,9 +2485,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_17962_2.7.8.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17962> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2515,7 +2514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2548,17 +2547,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-dimethylethanolamine &rarr; a phosphatidylcholine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2569,11 +2568,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_59789_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2581,19 +2580,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_59789_RXN4FS-2>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2603,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2614,23 +2602,12 @@
           <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_YeastPathways_PWY3O-2/YeastPathways_PWY3O-2_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2644,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2663,7 +2640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2684,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2697,7 +2674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2714,7 +2691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2730,7 +2707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2744,7 +2721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2760,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2785,7 +2762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2801,7 +2778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2816,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2843,7 +2820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2862,7 +2839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2878,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2892,7 +2869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2903,7 +2880,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2914,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2929,13 +2917,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17152>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001165> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2944,7 +2935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2961,13 +2952,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32345> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004142> ;
@@ -2986,7 +2988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2999,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3014,7 +3016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3030,7 +3032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3046,7 +3048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3060,7 +3062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3074,7 +3076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3093,7 +3095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3113,7 +3115,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c3861b5e-c8ac-47c8-a89e-e5be95ee1fd4_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3121,7 +3123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3137,7 +3139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3157,7 +3159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3170,7 +3172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3190,7 +3192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3210,7 +3212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3223,7 +3225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3237,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3251,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3265,7 +3267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3284,7 +3286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3302,13 +3304,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15958>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16110_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3319,7 +3324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3336,17 +3341,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_17962_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3362,7 +3367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3392,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3409,7 +3414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3425,7 +3430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3436,28 +3441,6 @@
           <http://model.geneontology.org/CHEBI_15354_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_e5a3ffbf-ec76-4a39-9756-e53236540eb5_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a 1,2-diacyl-<i>sn</i>-glycerol + CDP-ethanolamine &rarr; an L-1-phosphatidylethanolamine + CMP + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
@@ -3466,7 +3449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3482,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3499,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3529,7 +3512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3540,7 +3523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3551,7 +3534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3560,12 +3543,12 @@
 <http://purl.obolibrary.org/obo/GO_0003881>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002411_RXN4FS-2_SGD_PWY_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15958_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3576,7 +3559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3590,7 +3573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3606,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3621,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3634,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3648,7 +3631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3667,7 +3650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3682,7 +3665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3698,7 +3681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,7 +3704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3734,7 +3717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3752,7 +3735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3768,7 +3751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,7 +3767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3795,7 +3778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3806,7 +3789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3821,7 +3804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3837,7 +3820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3839,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002413_RXN3O-349_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3870,7 +3864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3889,7 +3883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3909,7 +3903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3922,7 +3916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3933,17 +3927,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+          "Provides Input For Rule. The relation '<i>S</i>-adenosyl-L-methionine + an L-1-phosphatidylethanolamine &rarr; a phosphatidyl-<i>N</i>-methylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' 'null' '<i>S</i>-adenosyl-L-methionine + a phosphatidyl-<i>N</i>-methylethanolamine &rarr; a phosphatidyl-<i>N</i>-dimethylethanolamine + <i>S</i>-adenosyl-L-homocysteine + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002411_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3958,7 +3952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3978,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3991,7 +3985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4002,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4016,7 +4010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4030,12 +4024,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_16110>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4052,7 +4046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4071,7 +4065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4091,7 +4085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4107,7 +4101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4122,7 +4116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4138,7 +4132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4154,7 +4148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4165,7 +4159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4182,7 +4176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4200,7 +4194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4216,7 +4210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4235,7 +4229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4255,7 +4249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4268,7 +4262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4278,11 +4272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4290,7 +4284,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4301,7 +4295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4331,7 +4325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4349,7 +4343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4368,7 +4362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4387,7 +4381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4401,7 +4395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4421,7 +4415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4434,7 +4428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4448,7 +4442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4467,7 +4461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4478,15 +4472,29 @@
           <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15958> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4501,7 +4509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4516,7 +4524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4532,7 +4540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4548,7 +4556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4563,7 +4571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4576,7 +4584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4588,7 +4596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4602,12 +4610,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_17152_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17962>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4618,7 +4640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4630,7 +4652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4646,7 +4668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4661,7 +4683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4677,7 +4699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4691,7 +4713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4707,7 +4729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4722,7 +4744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4737,11 +4759,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_37393_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4749,7 +4771,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4760,7 +4782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4779,7 +4801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4798,7 +4820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4814,7 +4836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4834,7 +4856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4850,7 +4872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4864,7 +4886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4880,7 +4902,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4894,7 +4927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4905,17 +4938,6 @@
           <http://model.geneontology.org/CHEBI_57876_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
@@ -4924,7 +4946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4944,7 +4966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4957,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4971,7 +4993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4986,7 +5008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5002,7 +5024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5022,7 +5044,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_17962_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_57880_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5030,7 +5052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5043,7 +5065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5055,7 +5077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5066,14 +5088,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/093c51e3-893d-4c78-b541-0ad1d2e1eabe_PHOSPHASERSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_17962_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17962> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5081,7 +5103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5096,7 +5118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5107,17 +5129,6 @@
 <http://identifiers.org/sgd/S000003834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16038> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5127,7 +5138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5143,7 +5154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5159,7 +5170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5174,7 +5185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5190,7 +5201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5202,7 +5213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5227,7 +5238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5243,7 +5254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5254,21 +5265,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_37393> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5276,7 +5304,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2>
@@ -5284,7 +5312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5298,7 +5326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5309,17 +5337,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-2/YeastPathways_PWY3O-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/2.1.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5329,17 +5346,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15958_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN4FS-2> , <http://model.geneontology.org/RXN3O-349> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN3O-349> , <http://model.geneontology.org/RXN4FS-2> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5358,7 +5375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5378,7 +5395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5395,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5408,22 +5425,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5434,32 +5459,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002333_YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR147W-MONOMER_ETHANOLAMINE-KINASE-RXN_controller>
-] .
 
 <http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5473,7 +5479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5486,7 +5492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5498,7 +5504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5517,7 +5523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5536,7 +5542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5547,29 +5553,12 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN>
 ] .
 
-<http://model.geneontology.org/70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_2.7.7.14-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5581,7 +5570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5601,7 +5590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5618,7 +5607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5642,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5653,6 +5642,17 @@
 <http://purl.obolibrary.org/obo/GO_0004305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
@@ -5661,7 +5661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5681,7 +5681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5697,7 +5697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5707,11 +5707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5719,18 +5719,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/70cf2286-7ad4-451d-9d37-247359225729_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17962_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5738,7 +5738,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/90ffafe2-e7ff-4d73-a6f5-be762ff2e55c_2.7.8.11-RXN>
+          <http://model.geneontology.org/CHEBI_17962_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
@@ -5746,7 +5746,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_17152_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_17962_PHOSPHASERSYN-RXN_SGD_PWY_YeastPathways_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5760,7 +5788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5779,7 +5807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5799,7 +5827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5816,7 +5844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5832,7 +5860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5843,36 +5871,16 @@
           <http://model.geneontology.org/CHEBI_57856_RXN4FS-2>
 ] .
 
-<http://model.geneontology.org/cd6ff8d2-bac9-482a-9e28-6d5985e511fd_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ed277332-e99e-4c6d-aca2-1ee6c76245c6_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5882,7 +5890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5912,7 +5920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5939,7 +5947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5955,7 +5963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5974,7 +5982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5993,7 +6001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6009,7 +6017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6021,7 +6029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6031,17 +6039,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_52eef56e-e533-4cef-9686-29752adf932a_2.1.1.17-RXN_SGD_PWY_YeastPathways_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -6054,7 +6051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6074,7 +6071,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f000c9df-a660-49c4-8de6-f1d7e0ec1e76_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_37393_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6082,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6099,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6112,7 +6109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -6123,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -6137,7 +6134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6153,7 +6150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -6164,7 +6161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -6179,7 +6176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6190,9 +6187,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/6cc940da-a3c6-4702-9b79-1e12cd712579_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
@@ -6201,7 +6195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6217,7 +6211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-20.ttl
+++ b/models/YeastPathways_PWY3O-20.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,17 +23,6 @@
 <http://purl.obolibrary.org/obo/GO_0004372>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
@@ -42,7 +31,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,28 +54,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64853> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -97,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +85,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,11 +134,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/48d1f632-5113-4180-888a-b0c13cfe8e81_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -176,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,6 +179,17 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller>
         a       <http://identifiers.org/sgd/S000005767> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,12 +235,34 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-20/YeastPathways_PWY3O-20>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_728c8d68-5ebf-4f28-98e7-0c82b321dc64_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -251,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +325,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b7afeeaa-39e6-4715-bd46-d817799adb37_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -311,11 +344,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +356,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_RXN0-2921>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
@@ -337,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,6 +381,17 @@
           <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/RXN3O-22>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -357,15 +401,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/b7afeeaa-39e6-4715-bd46-d817799adb37_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/1034c067-915f-411f-b424-ce2b497e0ffe_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,23 +461,29 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/728c8d68-5ebf-4f28-98e7-0c82b321dc64_FOLYLPOLYGLUTAMATESYNTH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -443,11 +493,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,8 +505,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_5cf6e297-17c5-4b55-8a66-88904a30cc96_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -465,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,23 +567,12 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -553,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,8 +637,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -599,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,12 +665,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_1034c067-915f-411f-b424-ce2b497e0ffe_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,15 +759,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_65ce5d48-8777-4bfd-b4f7-401480f3d896_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,8 +778,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/65ce5d48-8777-4bfd-b4f7-401480f3d896_DIHYDROFOLATEREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f000c192-4ac3-4594-b65b-26c21e5990a8_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -716,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,11 +811,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_728c8d68-5ebf-4f28-98e7-0c82b321dc64_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,8 +823,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN>
+          <http://model.geneontology.org/728c8d68-5ebf-4f28-98e7-0c82b321dc64_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_57451_RXN3O-681>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57451>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -754,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,17 +884,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' '10-formyl-tetrahydropteroyl-[&gamma;-Glu]<sub>(n)</sub> + L-glutamate + ATP &rarr; 10-formyl-tetrahydropteroyl-[&gamma;-Glu]<sub>(n+1)</sub> + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -806,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,23 +942,12 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -895,17 +984,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/5cf6e297-17c5-4b55-8a66-88904a30cc96_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -944,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -969,15 +1058,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,17 +1124,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1060,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1070,11 +1145,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_48d1f632-5113-4180-888a-b0c13cfe8e81_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,7 +1157,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN>
+          <http://model.geneontology.org/48d1f632-5113-4180-888a-b0c13cfe8e81_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1093,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,32 +1179,15 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_30616_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,7 +1195,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_RXN0-2921>
+          <http://model.geneontology.org/CHEBI_29985_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_30616_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
@@ -1145,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1154,29 +1212,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1186,11 +1227,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_5cf6e297-17c5-4b55-8a66-88904a30cc96_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1239,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/5cf6e297-17c5-4b55-8a66-88904a30cc96_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_PWY_YeastPathways_PWY3O-20>
@@ -1206,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1257,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,11 +1313,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_134413_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,8 +1325,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMYLTHFGLUSYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_134413_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1295,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,11 +1362,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_1034c067-915f-411f-b424-ce2b497e0ffe_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,18 +1374,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22>
+          <http://model.geneontology.org/1034c067-915f-411f-b424-ce2b497e0ffe_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,7 +1393,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
@@ -1349,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1360,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1375,32 +1427,21 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/2db4f5c5-8789-4d57-ba9b-2fdb7777ed27_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/728c8d68-5ebf-4f28-98e7-0c82b321dc64_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20BiochemicalReaction65005> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1410,7 +1451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,6 +1462,17 @@
           <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1430,28 +1482,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64881> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1463,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,11 +1514,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_29985_RXN0-2921>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -1494,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,30 +1554,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'methylene-tetrahydropteroyl-[&gamma;-Glu]<sub>(n)</sub> + L-glutamate + ATP &rarr; methylene-tetrahydropteroyl-[&gamma;-Glu]<sub>(n+1)</sub> + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1540,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,14 +1597,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1576,7 +1614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,22 +1630,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/1034c067-915f-411f-b424-ce2b497e0ffe_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1617,7 +1661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,6 +1672,9 @@
           <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/b7afeeaa-39e6-4715-bd46-d817799adb37_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
@@ -1636,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,35 +1703,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64767> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1694,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1723,11 +1748,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_57451_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,7 +1760,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681>
+          <http://model.geneontology.org/CHEBI_57451_RXN3O-681>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
@@ -1743,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1758,15 +1783,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-681_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> , <http://model.geneontology.org/CHEBI_57451_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681> , <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> ;
+                <http://model.geneontology.org/CHEBI_57451_RXN3O-681> , <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1778,11 +1803,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_f000c192-4ac3-4594-b65b-26c21e5990a8_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,7 +1815,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/f000c192-4ac3-4594-b65b-26c21e5990a8_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005767>
@@ -1805,32 +1830,21 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-2921_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> , <http://model.geneontology.org/CHEBI_20502_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN0-2921_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20BiochemicalReaction65000> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1840,7 +1854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1850,9 +1864,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1871,7 +1882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1882,12 +1893,29 @@
           <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
+<http://model.geneontology.org/65ce5d48-8777-4bfd-b4f7-401480f3d896_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000066_reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,22 +1943,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_17839>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_48d1f632-5113-4180-888a-b0c13cfe8e81_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-681>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1941,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1964,34 +1986,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-2921> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN>
-] .
-
-<http://model.geneontology.org/0effdf57-b46a-4601-9d03-fcb3d29a9480_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_20502_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2001,11 +2001,44 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_30616_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-2921> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_RXN0-2921>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/5cf6e297-17c5-4b55-8a66-88904a30cc96_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,7 +2046,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
@@ -2021,7 +2054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2039,15 +2072,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_134413_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2060,49 +2093,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_456216_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2113,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2126,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2141,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2157,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2175,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2204,11 +2217,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_456216_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2229,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005762>
@@ -2227,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2287,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2300,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2314,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,17 +2347,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/11f07e7c-fb49-4320-8d08-c4bb78b31666_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/f000c192-4ac3-4594-b65b-26c21e5990a8_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/RXN0-2921> , <http://model.geneontology.org/1.5.1.20-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/1.5.1.20-RXN> , <http://model.geneontology.org/RXN0-2921> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2352,34 +2365,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_43dc3a7d-11db-4338-8adb-c808bf7be6c3_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2387,17 +2378,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5-methyltetrahydrofolate + NAD<sup>+</sup> &larr; a 5,10-methylenetetrahydrofolate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2412,7 +2403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,7 +2425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,29 +2442,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002333_YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2487,7 +2472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,6 +2483,9 @@
           <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/f000c192-4ac3-4594-b65b-26c21e5990a8_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2506,7 +2494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2517,28 +2505,6 @@
           <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_bd5286c0-88e4-4025-9a61-ffb082eee8fe_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2548,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,13 +2531,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64784> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2581,7 +2550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,17 +2561,6 @@
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_bb6b777d-b509-4ab1-8772-e0d88f2d12fc_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2612,7 +2570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2646,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2662,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,17 +2631,6 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-681>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
@@ -2692,7 +2639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,47 +2650,52 @@
           <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000000467>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_CHEBI_29985_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_57451_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000467>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000066_reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_65ce5d48-8777-4bfd-b4f7-401480f3d896_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003093> ;
@@ -2752,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2768,7 +2720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2790,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2805,11 +2757,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2817,35 +2769,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_20502_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2853,15 +2788,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN0-2921>
+          <http://model.geneontology.org/CHEBI_20502_RXN0-2921>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_2db4f5c5-8789-4d57-ba9b-2fdb7777ed27_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2874,7 +2820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2891,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2904,7 +2850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2917,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2929,11 +2875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2941,7 +2887,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-20>
@@ -2953,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate polyglutamylation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2968,11 +2914,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2980,7 +2926,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN0-2921>
+          <http://model.geneontology.org/CHEBI_43474_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -2990,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3007,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3024,7 +2970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3039,11 +2985,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3051,8 +2997,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a08cde20-b525-45e4-9459-cb3a138cd26e_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3062,7 +3019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3073,15 +3030,12 @@
           <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/33debf0a-0ea7-43b0-960a-b1628e581db6_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000066_reaction_RXN0-2921_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3096,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3112,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3128,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3136,17 +3090,6 @@
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_0c468d99-723f-4e44-bc2f-33d54e854cd5_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3159,7 +3102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3182,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3198,7 +3141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3209,12 +3152,23 @@
           <http://model.geneontology.org/RXN3O-681>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3225,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3233,11 +3187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3245,7 +3199,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3256,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3270,7 +3224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3290,7 +3244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3306,7 +3260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3322,28 +3276,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3353,7 +3290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,7 +3306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3379,11 +3316,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_134413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3391,7 +3328,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -3401,7 +3338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3418,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3434,7 +3371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3453,7 +3390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3469,7 +3406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3480,7 +3417,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3493,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3509,7 +3457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3527,11 +3475,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3539,29 +3487,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_2db4f5c5-8789-4d57-ba9b-2fdb7777ed27_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3569,7 +3506,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eb654138-4915-429b-add9-a9e49f8fadcd_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/2db4f5c5-8789-4d57-ba9b-2fdb7777ed27_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-20>
@@ -3577,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3588,7 +3525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3596,11 +3533,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3608,7 +3545,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN>
@@ -3620,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3637,7 +3574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3653,18 +3590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3679,11 +3605,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64820> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_134413_FORMYLTHFGLUSYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_134413> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3695,7 +3638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3706,7 +3649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3717,7 +3660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3727,11 +3670,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3739,7 +3682,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6bb5f630-6661-4d97-97df-84b8ee79c9be_RXN0-2921>
+          <http://model.geneontology.org/CHEBI_456216_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000066_reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-20>
@@ -3747,7 +3690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3762,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3778,7 +3721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3794,16 +3737,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/2db4f5c5-8789-4d57-ba9b-2fdb7777ed27_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_YeastPathways_PWY3O-20/YeastPathways_PWY3O-20_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3820,7 +3766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3840,9 +3786,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/285f2105-f945-4241-8980-bbdfdc802cb9_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/c298a070-ec3a-4344-ab47-344123226f90_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/65ce5d48-8777-4bfd-b4f7-401480f3d896_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3850,13 +3796,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20BiochemicalReaction64831> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_57451_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -3867,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3883,7 +3840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3899,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3913,7 +3870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3927,7 +3884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3943,7 +3900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3957,7 +3914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3968,29 +3925,12 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4004,7 +3944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4014,11 +3954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4026,7 +3966,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/1.5.1.20-RXN>
@@ -4038,9 +3978,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/be6dec46-4c5b-46e5-a44c-38a2fa594f24_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/48d1f632-5113-4180-888a-b0c13cfe8e81_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4048,7 +3988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4064,7 +4004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4084,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4100,7 +4040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4116,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4130,7 +4070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4139,18 +4079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_94b46370-0999-4886-8712-14de8b6e4c34_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4159,7 +4088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4173,7 +4102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4186,7 +4115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4203,7 +4132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4215,11 +4144,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b7afeeaa-39e6-4715-bd46-d817799adb37_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4227,7 +4156,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5790e7ba-4d59-43ea-8c6c-c4e757e138d9_1.5.1.20-RXN>
+          <http://model.geneontology.org/b7afeeaa-39e6-4715-bd46-d817799adb37_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
@@ -4237,11 +4166,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4249,8 +4178,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_20502_RXN0-2921>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0008841> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4273,7 +4219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4289,7 +4235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,12 +4246,23 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4315,11 +4272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_57451_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4327,7 +4284,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36ebaeaf-e94f-4c49-890e-caa2a4d73625_RXN3O-681>
+          <http://model.geneontology.org/CHEBI_57451_RXN3O-681>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
@@ -4339,7 +4296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4359,7 +4316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4372,7 +4329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4382,11 +4339,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4394,7 +4351,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e4b3190f-90ae-487b-a78a-052553392514_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-20>
@@ -4402,7 +4359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4416,7 +4373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4435,7 +4392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4451,7 +4408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4466,7 +4423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4479,7 +4436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4493,7 +4450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4507,7 +4464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4521,6 +4478,23 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/CHEBI_134413_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
@@ -4529,7 +4503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4548,7 +4522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4559,12 +4533,29 @@
           <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4575,7 +4566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4590,7 +4581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4607,21 +4598,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule65023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_de830213-55de-4583-b599-b76262ddfbd0_RXN3O-681_SGD_PWY_YeastPathways_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-214.ttl
+++ b/models/YeastPathways_PWY3O-214.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tryptophan degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -876,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,23 +930,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_4.1.1.74-RXN_RO_0002333_CPLX3O-71_4.1.1.74-RXN_controller_SGD_PWY_YeastPathways_PWY3O-214>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002413_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,7 +1117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1417,7 +1417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1511,7 +1511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1561,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1577,7 +1577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1616,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1648,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,7 +1691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,7 +1780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1820,7 +1820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1840,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1856,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1884,7 +1884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1900,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1923,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1948,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1962,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1981,7 +1981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2027,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2069,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2121,7 +2121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2132,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2154,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-214" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-2220.ttl
+++ b/models/YeastPathways_PWY3O-2220.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of adenine, hypoxanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -813,24 +813,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220SmallMolecule48104> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -844,13 +833,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2220SmallMolecule48231> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YML035C-MONOMER_AMP-DEAMINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004498> ;
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,6 +1125,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456215_ADENOSINE-KINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/INOPHOSPHOR-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004731> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1145,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,23 +1164,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-2220/YeastPathways_PWY3O-2220_SGD_PWY_YeastPathways_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002333_YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-2220>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1353,7 +1353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1372,7 +1372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,7 +1449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1497,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1513,7 +1513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,7 +1674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1688,7 +1688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1812,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1826,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1862,7 +1862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,7 +1881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1976,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1991,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2033,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2157,7 +2157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2183,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2198,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2214,7 +2214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2231,7 +2231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2250,7 +2250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2266,7 +2266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2277,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2328,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2344,7 +2344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2363,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2388,7 +2388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2404,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-224.ttl
+++ b/models/YeastPathways_PWY3O-224.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12,7 +12,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-224" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-230.ttl
+++ b/models/YeastPathways_PWY3O-230.ttl
@@ -1,3 +1,20 @@
+<http://model.geneontology.org/768b6e4b-5ea3-4cf0-bd10-79477bde64db_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50230> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-230>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "serine biosynthesis from glyoxylate - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -22,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,11 +51,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +63,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004372>
@@ -60,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -71,18 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -90,6 +96,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0006564>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_768b6e4b-5ea3-4cf0-bd10-79477bde64db_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -102,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -112,11 +129,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,7 +141,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -134,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,17 +171,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-230/YeastPathways_PWY3O-230>
         a       <http://purl.obolibrary.org/obo/GO_0006564> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -174,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -190,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,28 +226,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50230> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -254,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -345,6 +334,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -356,11 +356,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_768b6e4b-5ea3-4cf0-bd10-79477bde64db_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/768b6e4b-5ea3-4cf0-bd10-79477bde64db_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -386,15 +386,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/defca0b5-12f8-42b5-be2d-478df964f4a9_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/768b6e4b-5ea3-4cf0-bd10-79477bde64db_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,31 +432,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/55306618-cacd-44d7-8188-3895cd99a63e_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -472,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,6 +468,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -495,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -521,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-236.ttl
+++ b/models/YeastPathways_PWY3O-236.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-236" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-238.ttl
+++ b/models/YeastPathways_PWY3O-238.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,24 +41,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42921> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -68,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -243,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -339,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -350,28 +339,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -380,11 +352,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_9a6f12f3-0a26-4485-84d3-477e97924f96_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +364,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22>
+          <http://model.geneontology.org/9a6f12f3-0a26-4485-84d3-477e97924f96_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -403,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,28 +394,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -459,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,23 +447,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_30616_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -637,7 +581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,6 +693,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_675bb1e5-c4ba-4e10-a960-1041db935bbd_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_9a6f12f3-0a26-4485-84d3-477e97924f96_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -758,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,12 +774,29 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/675bb1e5-c4ba-4e10-a960-1041db935bbd_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-238>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -828,9 +811,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> , <http://model.geneontology.org/8b1d00f3-b2fd-42af-aab5-69c7ec588c4d_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/9a6f12f3-0a26-4485-84d3-477e97924f96_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/675bb1e5-c4ba-4e10-a960-1041db935bbd_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -838,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -873,11 +856,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_675bb1e5-c4ba-4e10-a960-1041db935bbd_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,7 +868,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/633b0d9b-6ca1-4876-8277-f67e6cdd666f_RXN3O-22>
+          <http://model.geneontology.org/675bb1e5-c4ba-4e10-a960-1041db935bbd_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY_YeastPathways_PWY3O-238>
@@ -893,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,3 +925,20 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/9a6f12f3-0a26-4485-84d3-477e97924f96_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/YeastPathways_PWY3O-242.ttl
+++ b/models/YeastPathways_PWY3O-242.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,20 +44,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-72_RXN3O-364_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005635> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +104,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-10938_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-10938> , <http://model.geneontology.org/05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-10938> , <http://model.geneontology.org/CHEBI_16851_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17283_RXN-10938> , <http://model.geneontology.org/CHEBI_43474_RXN-10938> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -139,24 +139,22 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002411_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.1.150-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN-10938>
-] .
+<http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -167,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,50 +173,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ATP &rarr; 1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate + ADP + H<SUP>+</SUP>' 'null' '1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002413_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.1.150-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN-10938>
+] .
 
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002234_CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -228,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,6 +241,23 @@
           <http://model.geneontology.org/1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_18348_2.7.1.68-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18348> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -266,7 +266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,13 +293,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER3O-72_RXN-10961_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005635> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -324,15 +324,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,6 +365,9 @@
           <http://model.geneontology.org/YDR208W-MONOMER_2.7.1.68-RXN_controller>
 ] .
 
+<http://identifiers.org/sgd/S000001264>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -376,7 +376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,13 +432,13 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-55_RXN3O-364_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 3,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,15 +487,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_17283_RXN-10938> , <http://model.geneontology.org/CHEBI_30616_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_16851_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFR019W-MONOMER_2.7.1.150-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-10938> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -601,20 +601,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-55_RXN-10961_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 3,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -735,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +812,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_CHEBI_16851_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -836,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,6 +894,17 @@
           <http://model.geneontology.org/RXN-10961>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002413_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-myo-inositol 3-phosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol + ATP &rarr; a 1-phosphatidyl-1D-myo-inositol 3-phosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -891,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -938,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -952,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -995,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1006,19 +1028,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000005426>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_456216_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1051,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.150-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN>
+          <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1037,7 +1062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,12 +1095,31 @@
           <http://model.geneontology.org/MONOMER3O-72_RXN-10961_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.7.1.68-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,24 +1142,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.7.1.68-RXN>
-] .
+<http://model.geneontology.org/CHEBI_16851_2.7.1.150-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16851> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-364>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1126,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1176,18 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1195,11 +1226,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_18348_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1238,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.68-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN>
+          <http://model.geneontology.org/CHEBI_18348_2.7.1.68-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005050>
@@ -1224,7 +1255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,17 +1300,6 @@
           <http://model.geneontology.org/CHEBI_57880_RXN3O-364>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002411_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -1288,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,7 +1324,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002413_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1322,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1385,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,13 +1491,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-107_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000005426> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,13 +1506,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER3O-111_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001264> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1530,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1541,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1558,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,9 +1600,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
 ] .
 
-<http://model.geneontology.org/3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -1580,7 +1608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,24 +1628,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002411_RXN-10938_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1627,7 +1644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,17 +1682,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004430> ;
@@ -1696,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1706,17 +1712,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" , "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002411_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002413_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.68-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1732,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1748,7 +1754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1770,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,9 +1806,6 @@
           <http://model.geneontology.org/RXN3O-364>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -1811,7 +1814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1852,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1889,20 +1892,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005635> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1915,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1929,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,7 +1957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1970,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,9 +1998,6 @@
           <http://model.geneontology.org/MONOMER3O-55_RXN-10961_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -2006,7 +2006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2069,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,13 +2100,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-72_RXN-10938_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000005635> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 4,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2139,7 +2139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2166,7 +2166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2229,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2269,7 +2269,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN> ;
+                <http://model.geneontology.org/CHEBI_18348_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,7 +2331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2345,7 +2345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,7 +2364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2375,6 +2375,9 @@
           <http://model.geneontology.org/reaction_RXN-10961_location_lociGO_0005829>
 ] .
 
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -2383,7 +2386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2403,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,29 +2414,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002234_CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_16851_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-86_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2449,13 +2460,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43025> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-69_RXN3O-364_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005050> ;
@@ -2464,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2473,13 +2487,13 @@
                 "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MONOMER3O-55_RXN-10938_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidylinositol 3,5-bisphosphate 5-phosphatase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2495,7 +2509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,9 +2520,6 @@
           <http://model.geneontology.org/YFR019W-MONOMER_2.7.1.150-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_456216_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2518,13 +2529,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43136> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_18348_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2534,7 +2556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2550,7 +2572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2561,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2575,7 +2597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2597,7 +2619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2613,21 +2635,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2638,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2653,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2683,15 +2702,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN> , <http://model.geneontology.org/CHEBI_30616_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
+                <http://model.geneontology.org/CHEBI_18348_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR208W-MONOMER_2.7.1.68-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2709,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,7 +2741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2733,7 +2752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2743,11 +2762,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_456216_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2755,7 +2774,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.68-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c7389b94-d9e8-46e3-8bc4-dadc71f2ab9b_2.7.1.68-RXN>
+          <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
@@ -2767,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2783,7 +2802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2802,7 +2821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2821,7 +2840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2848,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2879,7 +2898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2895,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2906,7 +2925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2917,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2932,13 +2951,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://identifiers.org/sgd/S000005635>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2948,7 +2970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2968,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2981,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2992,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3006,7 +3028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3028,7 +3050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3044,7 +3066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3055,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3066,7 +3088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3078,7 +3100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3094,7 +3116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3109,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,7 +3158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3149,7 +3171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3160,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3171,7 +3193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3185,7 +3207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3207,7 +3229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3225,7 +3247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3241,7 +3263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3260,7 +3282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3268,11 +3290,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_CHEBI_16851_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,7 +3302,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10938> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN>
+          <http://model.geneontology.org/CHEBI_16851_2.7.1.150-RXN>
 ] .
 
 <http://model.geneontology.org/YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller>
@@ -3290,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3306,7 +3328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3320,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3334,7 +3356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3348,7 +3370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3359,29 +3381,12 @@
           <http://model.geneontology.org/YNL267W-MONOMER_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/944d6cc3-d88b-4f77-aa3a-585381b1d16c_2.7.1.150-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_BFO_0000050_YeastPathways_PWY3O-242/YeastPathways_PWY3O-242_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3414,7 +3419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3425,23 +3430,23 @@
           <http://model.geneontology.org/2.7.1.150-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_18348_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_BFO_0000066_reaction_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3451,11 +3456,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_18348_2.7.1.68-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3463,7 +3468,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3a47746a-d7d9-4249-bff7-1de5afe74932_2.7.1.68-RXN>
+          <http://model.geneontology.org/CHEBI_18348_2.7.1.68-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-10961_location_lociGO_0005829>
@@ -3471,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3480,7 +3485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3493,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3505,11 +3510,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_456216_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_CHEBI_16851_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3517,7 +3522,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.150-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN>
+          <http://model.geneontology.org/CHEBI_16851_2.7.1.150-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
@@ -3525,7 +3530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3539,7 +3544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3558,7 +3563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3577,7 +3582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3588,79 +3593,15 @@
           <http://model.geneontology.org/RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_05cd8bbc-1054-4d6a-8aab-934e060b85a4_2.7.1.150-RXN_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_16851>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_30616_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43121> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_15377_RXN-10961>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3674,7 +3615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3685,6 +3626,65 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_30616_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43121> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15377_RXN-10961>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42976> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002413_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004439>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
@@ -3693,7 +3693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3704,15 +3704,12 @@
           <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004439>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3726,7 +3723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3742,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3756,7 +3753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3772,18 +3769,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3794,7 +3794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3805,7 +3805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3816,7 +3816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3830,7 +3830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3840,3 +3840,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-242/YeastPathways_PWY3O-242>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_18348>
+        a       <http://www.w3.org/2002/07/owl#Class> .

--- a/models/YeastPathways_PWY3O-246.ttl
+++ b/models/YeastPathways_PWY3O-246.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -222,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -273,7 +273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "(R,R)-butanediol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-246" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-259.ttl
+++ b/models/YeastPathways_PWY3O-259.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,13 +326,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-259" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57603_ETHANOLAMINE-KINASE-RXN>
+] .
 
 <http://model.geneontology.org/2.7.7.14-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004306> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -353,32 +372,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-259BiochemicalReaction20934> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-259> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ETHANOLAMINE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57603_ETHANOLAMINE-KINASE-RXN>
-] .
 
 <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004307> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis II (Kennedy pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-261.ttl
+++ b/models/YeastPathways_PWY3O-261.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,19 +306,19 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57305>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_PSERTRANSAM-RXN_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57305>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15343_THREONINE-ALDOLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -373,12 +373,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_15343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/54de0c8a-7e1c-470c-ac8f-763b54b1ed0e_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002234_CHEBI_33384_RXN0-5114_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,8 +501,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -495,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,16 +531,19 @@
           <http://model.geneontology.org/CHEBI_15377_RXN0-5114>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THREONINE-ALDOLASE-RXN_RO_0002234_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -525,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,28 +563,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_BFO_0000050_YeastPathways_PWY3O-261/YeastPathways_PWY3O-261_SGD_PWY_YeastPathways_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -568,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -789,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,11 +827,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +839,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261>
@@ -841,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -855,11 +861,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
+<http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_PGLYCDEHYDROG-RXN>
@@ -871,31 +877,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41148> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16810>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glu" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41195> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -918,13 +904,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261BiochemicalReaction41164> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_29985_PSERTRANSAM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glu" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41195> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57926_THREONINE-ALDOLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57926> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -935,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -962,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,6 +979,9 @@
           <http://model.geneontology.org/CHEBI_43474_RXN0-5114>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0008453>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
@@ -981,7 +990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,9 +1001,6 @@
           <http://model.geneontology.org/CHEBI_57540_PGLYCDEHYDROG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0008453>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1003,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,28 +1109,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58272_PGLYCDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58272> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1135,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1211,11 +1200,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_54de0c8a-7e1c-470c-ac8f-763b54b1ed0e_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,8 +1212,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/54de0c8a-7e1c-470c-ac8f-763b54b1ed0e_GLYOHMETRANS-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001336>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1241,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1267,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1350,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1358,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1377,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1410,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1440,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_54de0c8a-7e1c-470c-ac8f-763b54b1ed0e_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1448,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1466,15 +1480,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/54de0c8a-7e1c-470c-ac8f-763b54b1ed0e_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1490,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1543,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1556,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1583,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1632,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1681,7 +1695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1695,11 +1709,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-261/YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009070> ;
@@ -1710,7 +1741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1723,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,11 +1783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_57305_THREONINE-ALDOLASE-RXN_SGD_PWY_YeastPathways_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1764,7 +1795,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_THREONINE-ALDOLASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
@@ -1772,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1798,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1857,7 +1888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,7 +1907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1925,7 +1956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1952,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +2013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2000,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2016,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2032,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2044,7 +2075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2077,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2093,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2105,7 +2136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2128,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2144,7 +2175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,7 +2194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2182,7 +2213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,23 +2243,6 @@
           <http://model.geneontology.org/CHEBI_16810_PSERTRANSAM-RXN>
 ] .
 
-<http://model.geneontology.org/2aa07cd7-eaf9-4742-9a9d-609643a11892_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
@@ -2237,7 +2251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2258,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2271,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2283,7 +2297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2313,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2324,17 +2338,6 @@
           <http://model.geneontology.org/reaction_PGLYCDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e63b736f-d3a6-4fcb-ab6c-9ff340f2317a_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2344,7 +2347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of serine and glycine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2363,6 +2366,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-285.ttl
+++ b/models/YeastPathways_PWY3O-285.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -35,11 +35,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule34047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/a905688c-0e59-48f3-b665-541633eb5ce1_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -48,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -358,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -684,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -779,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -844,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,6 +949,23 @@
           <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/e4c55575-3675-4106-a9d5-480a26291e9e_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -940,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1244,18 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1315,7 +1338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1331,7 +1354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1399,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1462,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1555,12 +1578,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1575,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,7 +1625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1649,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1803,27 +1837,31 @@
           <http://model.geneontology.org/CHEBI_15378_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_15378_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
+        a       <http://identifiers.org/sgd/S000002634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenylate kinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33801> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1833,7 +1871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,27 +1882,23 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/YDR226W-MONOMER_ADENYL-KIN-RXN_controller>
-        a       <http://identifiers.org/sgd/S000002634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenylate kinase" ;
+<http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002413_DGDPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33801> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002234_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1878,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1942,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1984,28 +2018,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2016,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2032,7 +2049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,12 +2060,29 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
+<http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2062,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2084,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2113,7 +2147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2129,7 +2163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,7 +2179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2160,7 +2194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2187,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2200,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2215,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2235,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2251,7 +2285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2271,7 +2305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,7 +2321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2339,7 +2373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2358,7 +2392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2378,7 +2412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2391,7 +2425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2405,7 +2439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2421,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2468,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2484,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2509,7 +2543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2525,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2570,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2581,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2592,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2607,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2623,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,6 +2668,23 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -2642,7 +2693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2661,7 +2712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2679,7 +2730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2701,7 +2752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2779,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_a905688c-0e59-48f3-b665-541633eb5ce1_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2739,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2754,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2770,7 +2832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2789,7 +2851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2800,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2811,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2825,7 +2887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2845,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2861,7 +2923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2891,7 +2953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2918,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2929,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2943,7 +3005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2962,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2978,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2993,7 +3055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3010,7 +3072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +3088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3048,7 +3110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3067,7 +3129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3083,7 +3145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3097,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,9 +3179,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN> , <http://model.geneontology.org/CHEBI_134413_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/a905688c-0e59-48f3-b665-541633eb5ce1_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3127,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3146,7 +3208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3157,12 +3219,27 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
+<http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001259> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "IMP dehydrogenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33785> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_456216_ADENYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3173,33 +3250,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001259> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "IMP dehydrogenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33785> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3213,7 +3275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3231,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3251,7 +3313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3267,7 +3329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,12 +3340,23 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_58115_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3297,7 +3370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3313,7 +3386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3331,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3347,7 +3420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3366,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3381,7 +3454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3394,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3408,7 +3481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3419,23 +3492,6 @@
           <http://model.geneontology.org/CHEBI_17368_INOPHOSPHOR-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fumarate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33834> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3445,11 +3501,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33472> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fumarate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33834> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3472,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3480,31 +3553,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_28938_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3515,11 +3569,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002234_CHEBI_456215_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-NH3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_456215_GMP-SYN-NH3-RXN>
+] .
 
 <http://identifiers.org/sgd/S000002807>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3533,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3546,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3559,7 +3632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,7 +3648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3594,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3609,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3628,7 +3701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3644,7 +3717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3654,11 +3727,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3666,7 +3739,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
@@ -3680,7 +3753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3694,7 +3767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3710,7 +3783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3723,7 +3796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3739,7 +3812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3755,7 +3828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3767,7 +3840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3786,7 +3859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3805,7 +3878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3828,7 +3901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3843,7 +3916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3856,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3867,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3882,7 +3955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3898,7 +3971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3914,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3931,7 +4004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3951,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3964,7 +4037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3975,7 +4048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3988,7 +4061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4001,7 +4074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4010,7 +4083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4025,7 +4098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4041,7 +4114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4061,7 +4134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4074,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4088,7 +4161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4104,7 +4177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4118,7 +4191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4134,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4145,7 +4218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4156,7 +4229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4170,7 +4243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4200,24 +4273,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction34018> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4227,7 +4289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4243,7 +4305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4254,7 +4316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4269,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4280,12 +4342,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_57567>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4298,7 +4363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4325,7 +4390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4341,7 +4406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4360,7 +4425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4378,7 +4443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4394,7 +4459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4414,7 +4479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4430,7 +4495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4449,7 +4514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4465,7 +4530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4476,7 +4541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4488,7 +4553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4508,7 +4573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4524,7 +4589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4544,7 +4609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4552,23 +4617,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002234_CHEBI_57720_INOPHOSPHOR-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002234_CHEBI_456216_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4582,7 +4647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4595,32 +4660,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENYL-KIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002333_YAR015W-MONOMER_SAICARSYN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4631,12 +4677,31 @@
           <http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_BFO_0000066_reaction_ADENYL-KIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENYL-KIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ADENYL-KIN-RXN_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4661,7 +4726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4674,7 +4739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4688,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4703,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4719,7 +4784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4730,7 +4795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4747,7 +4812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4763,7 +4828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4774,7 +4839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4785,7 +4850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4799,7 +4864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4813,7 +4878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4831,7 +4896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4844,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4853,7 +4918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4864,7 +4929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4878,7 +4943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4908,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4925,7 +4990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4942,7 +5007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4958,7 +5023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4978,7 +5043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4998,7 +5063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5014,7 +5079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5031,7 +5096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5050,7 +5115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5066,7 +5131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5080,7 +5145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5098,7 +5163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5115,7 +5180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5131,7 +5196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5150,7 +5215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5166,7 +5231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5180,7 +5245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5194,7 +5259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5216,7 +5281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5246,7 +5311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5259,7 +5324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5271,7 +5336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5290,7 +5355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5306,7 +5371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5317,7 +5382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5328,35 +5393,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_BFO_0000066_reaction_AMPSYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5367,7 +5415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5381,7 +5429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5397,7 +5445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5408,7 +5456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5419,7 +5467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5430,7 +5478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5441,7 +5489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5455,7 +5503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5471,7 +5519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5482,7 +5530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5496,7 +5544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5512,7 +5560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5523,7 +5571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5535,7 +5583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5555,7 +5603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5568,7 +5616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5582,7 +5630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5596,7 +5644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5612,7 +5660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5624,7 +5672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5644,7 +5692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5660,7 +5708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5680,7 +5728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5696,7 +5744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5721,7 +5769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5737,7 +5785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5748,7 +5796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5762,7 +5810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5781,7 +5829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5800,7 +5848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5820,7 +5868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5837,7 +5885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5850,7 +5898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5864,7 +5912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5883,7 +5931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5899,7 +5947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5908,7 +5956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5931,7 +5979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5947,7 +5995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5967,7 +6015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5983,7 +6031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6001,7 +6049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6018,28 +6066,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33732> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dGDP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33529> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6051,7 +6082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6062,12 +6093,29 @@
           <http://model.geneontology.org/reaction_RXN0-746_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dGDP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33529> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000066_reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6078,7 +6126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6092,7 +6140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6108,7 +6156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6124,7 +6172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6140,7 +6188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6159,7 +6207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6173,7 +6221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6189,7 +6237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6203,7 +6251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6218,7 +6266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6234,7 +6282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6254,24 +6302,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6282,7 +6319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6299,7 +6336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6312,7 +6349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6324,7 +6361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6342,11 +6379,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_e4c55575-3675-4106-a9d5-480a26291e9e_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6354,7 +6391,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/e4c55575-3675-4106-a9d5-480a26291e9e_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -6365,7 +6402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6373,11 +6410,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6385,7 +6422,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN>
+          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
@@ -6393,7 +6430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6407,7 +6444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6426,7 +6463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6445,7 +6482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6464,7 +6501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6483,7 +6520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6497,7 +6534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6519,7 +6556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6535,7 +6572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6546,7 +6583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6564,7 +6601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6577,7 +6614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6591,7 +6628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6611,7 +6648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6624,7 +6661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6638,7 +6675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6654,7 +6691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6669,7 +6706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6682,7 +6719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6697,7 +6734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6716,7 +6753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6732,7 +6769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6741,7 +6778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6755,7 +6792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6769,7 +6806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6788,7 +6825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6804,7 +6841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6819,7 +6856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6836,7 +6873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6853,7 +6890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6869,7 +6906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6899,7 +6936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6912,7 +6949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6926,7 +6963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6945,7 +6982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6960,7 +6997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6987,7 +7024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7002,7 +7039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7018,7 +7055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7038,7 +7075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7054,7 +7091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7074,7 +7111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7090,7 +7127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7110,7 +7147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7126,7 +7163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7145,7 +7182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7161,7 +7198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7176,7 +7213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7189,7 +7226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7203,7 +7240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7214,6 +7251,15 @@
           <http://model.geneontology.org/YGR061C-MONOMER_FGAMSYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -7222,7 +7268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7233,15 +7279,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
 ] .
 
-<http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -7250,7 +7287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7269,7 +7306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7280,7 +7317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7294,7 +7331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7314,7 +7351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7331,7 +7368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7344,7 +7381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7357,7 +7394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7376,7 +7413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7396,7 +7433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7426,7 +7463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7442,7 +7479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7458,7 +7495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7472,7 +7509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7488,7 +7525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7502,7 +7539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7516,7 +7553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7535,7 +7572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7558,7 +7595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7574,7 +7611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7593,7 +7630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7615,7 +7652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7635,7 +7672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7646,12 +7683,23 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002413_DADPKIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7666,24 +7714,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33302> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_43474_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7693,7 +7730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7709,7 +7746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7720,7 +7757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7734,7 +7771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7753,7 +7790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7773,7 +7810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7789,7 +7826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7805,7 +7842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7819,7 +7856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7838,7 +7875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7849,7 +7886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7877,7 +7914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7890,7 +7927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7905,7 +7942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7921,7 +7958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7937,7 +7974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7948,7 +7985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7963,7 +8000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7984,7 +8021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8000,7 +8037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8016,7 +8053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8030,7 +8067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8039,7 +8076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8053,7 +8090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8069,7 +8106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8080,7 +8117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8089,7 +8126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8100,7 +8137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8114,7 +8151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8130,7 +8167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8141,7 +8178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8158,7 +8195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8174,18 +8211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8196,7 +8222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8211,7 +8237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8230,7 +8256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8244,7 +8270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8263,7 +8289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8279,7 +8305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8290,7 +8316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8304,7 +8330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8323,7 +8349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8342,7 +8368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8358,7 +8384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8372,7 +8398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8391,7 +8417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8406,11 +8432,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_a905688c-0e59-48f3-b665-541633eb5ce1_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8418,7 +8444,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/738fc3f5-d409-4335-968b-78914f3bf7fa_GART-RXN>
+          <http://model.geneontology.org/a905688c-0e59-48f3-b665-541633eb5ce1_GART-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
@@ -8426,7 +8452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8438,7 +8464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8456,7 +8482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8483,7 +8509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8496,7 +8522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8505,23 +8531,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8532,7 +8558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8543,7 +8569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8557,7 +8583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8577,7 +8603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8590,7 +8616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8601,7 +8627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8615,7 +8641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8634,7 +8660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8653,7 +8679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8669,7 +8695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8681,7 +8707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8697,7 +8723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8710,7 +8736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8730,7 +8756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8743,7 +8769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8754,7 +8780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8771,7 +8797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8790,7 +8816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8809,7 +8835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8825,7 +8851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8839,7 +8865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8859,7 +8885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8875,7 +8901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8895,7 +8921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8911,7 +8937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8927,7 +8953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8941,7 +8967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8960,7 +8986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8975,7 +9001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine biosynthesis and salvage pathways - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -8983,24 +9009,16 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SAICARSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
-] .
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9010,7 +9028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9025,11 +9043,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SAICARSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-285/YeastPathways_PWY3O-285>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_16708_ADENPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9040,23 +9077,23 @@
           <http://model.geneontology.org/CHEBI_16708_ADENPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002413_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002233_CHEBI_58359_PRPPAMIDOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9071,7 +9108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9087,7 +9124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9098,23 +9135,12 @@
           <http://model.geneontology.org/CHEBI_28938_ADENINE-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002233_CHEBI_58115_GMP-SYN-NH3-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_BFO_0000066_reaction_ADPREDUCT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9125,7 +9151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9140,7 +9166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9156,7 +9182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9170,7 +9196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9186,7 +9212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9197,7 +9223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9211,7 +9237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9232,7 +9258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9248,7 +9274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9270,7 +9296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9290,7 +9316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9303,7 +9329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9317,7 +9343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9333,7 +9359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9348,7 +9374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9365,7 +9391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9381,7 +9407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9400,7 +9426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9418,7 +9444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9431,7 +9457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9448,7 +9474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9464,7 +9490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9478,7 +9504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9494,7 +9520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9507,7 +9533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9523,7 +9549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9538,11 +9564,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_58475_AICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_CHEBI_134413_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9550,7 +9576,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
@@ -9558,7 +9584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9573,7 +9599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9589,7 +9615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9604,11 +9630,30 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YDR226W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9628,32 +9673,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33286> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/CHEBI_137981>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -9666,7 +9692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9682,7 +9708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9696,7 +9722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9715,7 +9741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9726,17 +9752,6 @@
           <http://model.geneontology.org/SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58426>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -9745,7 +9760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9756,7 +9771,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002233_CHEBI_58443_SAICARSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9767,7 +9793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9785,7 +9811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9801,7 +9827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9820,7 +9846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9836,7 +9862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9848,16 +9874,22 @@
 <http://identifiers.org/sgd/S000001550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_16335_ADENOSINE-KINASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16335> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenosine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule34155> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9867,7 +9899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9878,29 +9910,23 @@
           <http://model.geneontology.org/CHEBI_29985_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_16335_ADENOSINE-KINASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16335> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenosine" ;
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule34155> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002234_CHEBI_29806_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9915,7 +9941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9931,7 +9957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9947,7 +9973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9965,7 +9991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9981,7 +10007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10000,7 +10026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10016,7 +10042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10029,7 +10055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10042,7 +10068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10056,7 +10082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10072,7 +10098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10086,7 +10112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10102,7 +10128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10116,7 +10142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10130,7 +10156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10149,7 +10175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10165,7 +10191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10177,7 +10203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10188,7 +10214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10201,7 +10227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10218,7 +10244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10231,7 +10257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10245,7 +10271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10267,7 +10293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10283,7 +10309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10294,7 +10320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10308,7 +10334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10319,34 +10345,12 @@
           <http://model.geneontology.org/CHEBI_456215_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10360,7 +10364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10371,12 +10375,34 @@
           <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002234_CHEBI_17596_RXN-7607_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58189_GUANYL-KIN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10390,7 +10416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10401,29 +10427,12 @@
           <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_BFO_0000050_YeastPathways_PWY3O-285/YeastPathways_PWY3O-285_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10438,7 +10447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10451,7 +10460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10465,7 +10474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10481,7 +10490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10492,7 +10501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10505,7 +10514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10524,7 +10533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10536,7 +10545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10547,23 +10556,23 @@
           <http://model.geneontology.org/CHEBI_58053_IMPCYCLOHYDROLASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002233_CHEBI_456215_AMPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_30616_GMP-SYN-GLUT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10574,7 +10583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10583,7 +10592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10595,7 +10604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10614,7 +10623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10632,7 +10641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10645,7 +10654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10668,7 +10677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10681,7 +10690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10695,7 +10704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10711,7 +10720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10722,7 +10731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10733,7 +10742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10744,7 +10753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10758,7 +10767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10774,7 +10783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10788,7 +10797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10808,7 +10817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10824,7 +10833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10854,7 +10863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10870,7 +10879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10892,7 +10901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10908,7 +10917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10917,7 +10926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10928,7 +10937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10939,7 +10948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -10951,7 +10960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10976,7 +10985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10998,7 +11007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11017,7 +11026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11037,7 +11046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11050,7 +11059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11069,7 +11078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11082,7 +11091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11093,43 +11102,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000070> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphoribosyl amino imidazolesuccinocarbozamide synthetase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33953> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/CHEBI_15740_RXN0-746>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "formate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33562> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11139,7 +11116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11150,6 +11127,38 @@
           <http://model.geneontology.org/IMP-DEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15740_RXN0-746>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "formate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33562> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YAR015W-MONOMER_SAICARSYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000070> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphoribosyl amino imidazolesuccinocarbozamide synthetase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33953> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -11158,7 +11167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11178,7 +11187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11197,7 +11206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11217,7 +11226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11233,7 +11242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11249,7 +11258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11258,7 +11267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11272,7 +11281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11291,7 +11300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11302,7 +11311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11313,7 +11322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11326,7 +11335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11342,7 +11351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11358,7 +11367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11372,7 +11381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11388,7 +11397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -11397,7 +11406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11411,7 +11420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11431,7 +11440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11448,7 +11457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11465,7 +11474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11481,7 +11490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11497,7 +11506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11511,7 +11520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11527,7 +11536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11542,7 +11551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11555,7 +11564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11569,7 +11578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11585,7 +11594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11599,7 +11608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11618,7 +11627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11634,7 +11643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11648,7 +11657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11668,7 +11677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11681,7 +11690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11692,7 +11701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11709,7 +11718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11725,7 +11734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11736,7 +11745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11750,7 +11759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11761,23 +11770,6 @@
           <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_30616_ADENYL-KIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11787,7 +11779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11800,7 +11792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11818,7 +11810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11831,7 +11823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11858,7 +11850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11874,7 +11866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11897,24 +11889,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule34067> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_GLYRIBONUCSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -11925,13 +11906,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002333_YKL067W-MONOMER_DGDPKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -11945,9 +11937,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7b9913d9-cd58-48e3-be0b-8dc40d186116_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_134413_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/aac98237-ee6c-4d3f-8a2a-8e6eb6d0f72a_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/e4c55575-3675-4106-a9d5-480a26291e9e_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -11955,7 +11947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11971,7 +11963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11987,7 +11979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11998,7 +11990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12009,7 +12001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12032,7 +12024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12045,7 +12037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12059,7 +12051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12075,7 +12067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12089,7 +12081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12119,7 +12111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12135,7 +12127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12151,7 +12143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12162,7 +12154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12173,7 +12165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12188,7 +12180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12204,7 +12196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12218,7 +12210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12236,11 +12228,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_134413_GART-RXN_SGD_PWY_YeastPathways_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12248,7 +12240,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58457_GLYRIBONUCSYN-RXN>
+          <http://model.geneontology.org/CHEBI_134413_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -12259,7 +12251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12275,7 +12267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12289,7 +12281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12305,7 +12297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12317,7 +12309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12336,7 +12328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12352,7 +12344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12366,7 +12358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12385,7 +12377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12405,7 +12397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12422,7 +12414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12435,7 +12427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12446,7 +12438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12459,7 +12451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12475,7 +12467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12494,7 +12486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12514,7 +12506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12541,7 +12533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12557,7 +12549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12568,6 +12560,9 @@
           <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004641>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -12576,7 +12571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12587,15 +12582,12 @@
           <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004641>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_CHEBI_15377_ADPREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12612,7 +12604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12628,7 +12620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12639,7 +12631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12653,7 +12645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12667,17 +12659,6 @@
 <http://identifiers.org/sgd/S000004351>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'IMP + H<sub>2</sub>O &harr; 5-formamido-1-(5-phospho-D-ribosyl)-imidazole-4-carboxamide' 'null' 'L-aspartate + IMP + GTP &rarr; adenylo-succinate + GDP + phosphate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -12686,7 +12667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12697,29 +12678,23 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ba471902-4da5-4bd5-93bb-9d6e9d5a8a75_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_BFO_0000066_reaction_ADENOSINE-KINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_30616_AIRS-RXN_SGD_PWY_YeastPathways_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12733,7 +12708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12744,7 +12719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12759,7 +12734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12772,7 +12747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12786,7 +12761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12805,7 +12780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12821,7 +12796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12832,7 +12807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12849,7 +12824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12868,7 +12843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12884,7 +12859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12898,7 +12873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12917,7 +12892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12939,7 +12914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12955,7 +12930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -12964,7 +12939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12975,7 +12950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12990,7 +12965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13003,7 +12978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13017,7 +12992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13036,7 +13011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13055,7 +13030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13071,7 +13046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13082,7 +13057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13093,7 +13068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13104,7 +13079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -13117,7 +13092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13130,7 +13105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13144,7 +13119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13160,7 +13135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13185,7 +13160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13212,13 +13187,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285BiochemicalReaction34053> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://identifiers.org/sgd/S000004830>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/Red-Thioredoxin_GDPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -13229,7 +13207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13245,7 +13223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13256,8 +13234,22 @@
           <http://model.geneontology.org/CHEBI_58017_PRPPAMIDOTRANS-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000004830>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/CHEBI_134413_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -13271,7 +13263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13284,7 +13276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13298,7 +13290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13314,7 +13306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13325,7 +13317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13352,7 +13344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13368,7 +13360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13387,7 +13379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13401,7 +13393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13415,7 +13407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13431,7 +13423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13442,7 +13434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13456,7 +13448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13475,7 +13467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13494,7 +13486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13510,7 +13502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13525,7 +13517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13541,7 +13533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13560,7 +13552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13579,7 +13571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13595,7 +13587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13609,7 +13601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13627,7 +13619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13640,7 +13632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13657,7 +13649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13670,7 +13662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13683,7 +13675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13697,7 +13689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13727,7 +13719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13740,7 +13732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13753,7 +13745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13766,7 +13758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13777,7 +13769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13791,7 +13783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13807,7 +13799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13818,7 +13810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13829,7 +13821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13843,7 +13835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13863,7 +13855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13882,7 +13874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13898,7 +13890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13909,7 +13901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13920,7 +13912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13933,7 +13925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13960,7 +13952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13973,7 +13965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13987,7 +13979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14007,7 +13999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14020,7 +14012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14033,7 +14025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14046,18 +14038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -14071,7 +14052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14082,6 +14063,17 @@
           <http://model.geneontology.org/CHEBI_15378_GMP-SYN-NH3-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_BFO_0000066_reaction_DADPKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -14090,7 +14082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14110,7 +14102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14129,7 +14121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -14141,7 +14133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14157,7 +14149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -14171,7 +14163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14201,7 +14193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14221,7 +14213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14240,7 +14232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14256,7 +14248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -14270,7 +14262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14281,6 +14273,17 @@
           <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_e4c55575-3675-4106-a9d5-480a26291e9e_AICARTRANSFORM-RXN_SGD_PWY_YeastPathways_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
@@ -14289,7 +14292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14311,7 +14314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14330,7 +14333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14350,7 +14353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-3.ttl
+++ b/models/YeastPathways_PWY3O-3.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -58,13 +58,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3Protein44008> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17962>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -81,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,15 +92,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_17962_2.7.8.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17962> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17962_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +125,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN>
+          <http://model.geneontology.org/CHEBI_17962_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN>
@@ -117,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,14 +153,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -154,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +201,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_CHEBI_17962_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -199,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -215,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +300,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_17962_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -280,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,23 +380,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -383,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -428,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,14 +483,3 @@
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_60371310-85bc-4226-8cfd-214dd35d56c6_2.7.8.11-RXN_SGD_PWY_YeastPathways_PWY3O-3>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-3" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-31704.ttl
+++ b/models/YeastPathways_PWY3O-31704.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,17 +38,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> , <http://model.geneontology.org/635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315> ;
+                <http://model.geneontology.org/CHEBI_146130_RXN66-315> , <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316> , <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_146131_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN66-317> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,11 +353,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +365,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-316>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-316>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -376,7 +376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -404,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,18 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -656,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -770,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,11 +774,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +786,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -808,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -986,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1039,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1055,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1070,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1198,11 +1187,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1199,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
@@ -1218,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1243,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,12 +1246,15 @@
 <http://identifiers.org/sgd/S000004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_143575>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-178_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,7 +1304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1331,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,6 +1334,23 @@
           <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_146130_RXN66-315>
+        a       <http://purl.obolibrary.org/obo/CHEBI_146130> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_128769_GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_128769> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1351,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,6 +1387,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-31704/YeastPathways_PWY3O-31704>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002413_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
@@ -1386,7 +1406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,23 +1417,12 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002234_CHEBI_29888_FPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1459,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1515,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1528,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1539,21 +1548,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002413_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1561,17 +1567,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' 'null' '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002411_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002413_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1586,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1619,7 +1625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1647,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1688,7 +1694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1802,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1815,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1843,7 +1849,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_143575_RXN66-317> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1853,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1869,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1880,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1906,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1930,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1939,7 +1945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1997,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2023,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2036,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2061,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2078,7 +2084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2094,7 +2100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2109,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2125,7 +2131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2147,7 +2153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2174,7 +2180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2185,7 +2191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2195,11 +2201,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2213,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315>
+          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
 ] .
 
 <http://identifiers.org/sgd/S000001114>
@@ -2221,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2251,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,7 +2276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2319,7 +2325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2346,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2355,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2380,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2393,12 +2399,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YGR175C-MONOMER_SQUALENE-MONOOXYGENASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003407> ;
@@ -2407,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,7 +2423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2434,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2445,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2454,7 +2457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2479,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2496,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2512,7 +2515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2531,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2562,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2576,7 +2579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2608,11 +2611,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2620,7 +2623,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-317>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-218_BFO_0000066_reaction_RXN3O-218_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
@@ -2628,7 +2631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2665,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2681,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2703,7 +2706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2722,7 +2725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2738,7 +2741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2752,7 +2755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2771,7 +2774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2787,7 +2790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2798,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2809,7 +2812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2822,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2837,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2855,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2871,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2894,7 +2897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2917,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2933,7 +2936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2949,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2958,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2969,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2983,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2994,7 +2997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3005,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3013,17 +3016,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" , "Provides Input For Rule. The relation '4&alpha;-methyl-zymosterol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; 4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + 2 H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002411_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002413_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3038,7 +3041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3057,7 +3060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3073,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3085,7 +3088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3101,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3115,7 +3118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3133,11 +3136,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_146131_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3145,7 +3148,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-317>
+          <http://model.geneontology.org/CHEBI_146131_RXN66-316>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3156,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3172,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3183,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3200,7 +3203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3216,7 +3219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3228,7 +3231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3244,7 +3247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3259,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3276,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3289,7 +3292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3300,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3321,7 +3324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3334,7 +3337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3359,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3374,7 +3377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3395,7 +3398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3411,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3430,7 +3433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3449,7 +3452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3465,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3498,7 +3501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3517,7 +3520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3537,7 +3540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3556,7 +3559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3574,7 +3577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3591,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3606,7 +3609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3622,7 +3625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3641,7 +3644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3657,7 +3660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3679,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3690,7 +3693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3724,7 +3727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3740,18 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002411_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3766,7 +3758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3779,7 +3771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3791,26 +3783,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN66-315>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3821,7 +3796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3838,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3854,7 +3829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3870,7 +3845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3884,7 +3859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3900,35 +3875,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002413_1.3.1.71-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3938,11 +3896,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3950,7 +3908,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-316>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -3964,7 +3922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3983,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3997,7 +3955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4016,7 +3974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4036,7 +3994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4046,17 +4004,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+          "Provides Input For Rule. The relation '4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + H<SUP>+</SUP> &rarr; 4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' '4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol + NAD(P)<sup>+</sup> &rarr; zymosterone + CO<SUB>2</SUB> + NAD(P)H' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002411_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002413_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4068,7 +4026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4083,7 +4041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4099,7 +4057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4118,7 +4076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4146,7 +4104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4159,7 +4117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4170,7 +4128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4181,11 +4139,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_146131>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN66-315>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000254> ;
@@ -4198,15 +4159,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN66-315> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_1949_RXN66-314> , <http://model.geneontology.org/CHEBI_15378_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
+                <http://model.geneontology.org/CHEBI_146130_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN66-316> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4219,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4232,7 +4193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4245,7 +4206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4260,7 +4221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4273,7 +4234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4286,7 +4247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4302,7 +4263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4318,7 +4279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4329,7 +4290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4343,7 +4304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4362,7 +4323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4372,9 +4333,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-227_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4388,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4404,7 +4362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4420,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4434,7 +4392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4453,7 +4411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4467,7 +4425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4486,7 +4444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4505,7 +4463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4535,7 +4493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4552,7 +4510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4564,11 +4522,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_146130_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4576,7 +4534,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN66-316>
+          <http://model.geneontology.org/CHEBI_146130_RXN66-315>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4587,7 +4545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4603,18 +4561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002411_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4625,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4639,7 +4586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4659,7 +4606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4672,18 +4619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_971baa4f-40eb-4520-99a8-4eaf82b107eb_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4694,7 +4630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4708,7 +4644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4723,7 +4659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4739,7 +4675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4764,7 +4700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4780,7 +4716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4796,7 +4732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4807,7 +4743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4818,7 +4754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4832,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4843,7 +4779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4854,9 +4790,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_146131_RXN66-316>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_146131> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4866,7 +4819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4885,7 +4838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4905,7 +4858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4921,7 +4874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4937,7 +4890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4947,11 +4900,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_FERROCYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4959,7 +4912,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4970,7 +4923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4989,7 +4942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5008,7 +4961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5024,7 +4977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5035,7 +4988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5052,7 +5005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5072,7 +5025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5085,7 +5038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5100,7 +5053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5113,7 +5066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5124,7 +5077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5140,7 +5093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5153,7 +5106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5170,7 +5123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5184,7 +5137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5200,7 +5153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5211,7 +5164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5236,7 +5189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5252,7 +5205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5271,7 +5224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5290,7 +5243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5306,7 +5259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5316,11 +5269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_FERRICYTOCHROME-B5_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5328,7 +5281,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315>
+          <http://model.geneontology.org/CHEBI_15377_RXN66-315>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -5342,7 +5295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5361,7 +5314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5381,7 +5334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5397,7 +5350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5416,7 +5369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5432,7 +5385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5448,7 +5401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5467,7 +5420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5478,7 +5431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5493,7 +5446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5516,7 +5469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5529,7 +5482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5542,7 +5495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5555,7 +5508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5570,7 +5523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5583,7 +5536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5594,18 +5547,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_143575_RXN66-317>
+        a       <http://purl.obolibrary.org/obo/CHEBI_143575> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002234_CHEBI_50586_RXN3O-203_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5619,7 +5589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5635,7 +5605,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_146131_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5649,7 +5630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5669,7 +5650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5685,7 +5666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5704,7 +5685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5715,23 +5696,23 @@
           <http://model.geneontology.org/CHEBI_29888_RXN-12263>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_17813_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_BFO_0000066_reaction_SQUALENE-MONOOXYGENASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002234_CHEBI_17813_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5742,7 +5723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5756,7 +5737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5772,7 +5753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5786,7 +5767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5805,7 +5786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5823,7 +5804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5836,7 +5817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5853,7 +5834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5872,7 +5853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5888,7 +5869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5903,7 +5884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5920,7 +5901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5933,7 +5914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5948,17 +5929,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> , <http://model.geneontology.org/e85795fa-65b3-4b37-b58c-1f457b8e0ac9_RXN66-316> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/CHEBI_146131_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/CHEBI_143575_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-317_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN66-318> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5971,7 +5952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5986,7 +5967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6001,7 +5982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6020,7 +6001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6040,7 +6021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6053,7 +6034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6068,7 +6049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6084,7 +6065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6103,7 +6084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6122,7 +6103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6141,7 +6122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6152,6 +6133,17 @@
           <http://model.geneontology.org/CHEBI_29888_RXN66-281>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002413_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
@@ -6160,7 +6152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6175,11 +6167,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_FERROCYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15379_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6187,7 +6179,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
+          <http://model.geneontology.org/CHEBI_15379_RXN66-316>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6198,7 +6190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6217,7 +6209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6239,7 +6231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6258,7 +6250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6277,7 +6269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6292,7 +6284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6319,7 +6311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6336,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6363,7 +6355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6383,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6391,23 +6383,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_16521_LANOSTEROL-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6421,7 +6413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6440,7 +6432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6451,26 +6443,15 @@
           <http://model.geneontology.org/reaction_RXN66-310_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_15377_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_143575_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6478,7 +6459,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-317>
+          <http://model.geneontology.org/CHEBI_143575_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6489,7 +6470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6505,7 +6486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6519,7 +6500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6538,7 +6519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6554,7 +6535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6568,7 +6549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6584,7 +6565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6598,7 +6579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6617,7 +6598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6633,7 +6614,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_146130_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_143575_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6644,7 +6647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6655,7 +6658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6669,7 +6672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6685,7 +6688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6710,7 +6713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6723,7 +6726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6736,7 +6739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6744,20 +6747,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/CHEBI_1949>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002413_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN3O-130_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://purl.obolibrary.org/obo/CHEBI_1949>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6767,7 +6778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6786,7 +6797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6805,7 +6816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6825,7 +6836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6841,7 +6852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6860,7 +6871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6878,7 +6889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6895,7 +6906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6911,7 +6922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6933,7 +6944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6952,7 +6963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6971,7 +6982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6990,7 +7001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7006,7 +7017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7017,7 +7028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7042,7 +7053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7062,7 +7073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7079,7 +7090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7092,7 +7103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7103,7 +7114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7121,7 +7132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7134,7 +7145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7145,7 +7156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7156,7 +7167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7167,7 +7178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7178,7 +7189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7192,7 +7203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7211,7 +7222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7226,11 +7237,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_143575_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7238,8 +7249,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cc905f95-a029-4f85-9c93-168fc7a92b70_RXN66-317>
+          <http://model.geneontology.org/CHEBI_143575_RXN66-317>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_146131_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7249,7 +7271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7269,7 +7291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7285,7 +7307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7301,7 +7323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7315,7 +7337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7334,7 +7356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7354,7 +7376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7367,7 +7389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7381,7 +7403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7397,7 +7419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7408,7 +7430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7422,7 +7444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7452,7 +7474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7465,7 +7487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7480,7 +7502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7497,7 +7519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7513,7 +7535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7529,7 +7551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7554,7 +7576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7571,7 +7593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7584,7 +7606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7599,7 +7621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7616,7 +7638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7632,7 +7654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7651,7 +7673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7670,7 +7692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7685,11 +7707,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_15377_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_CHEBI_146131_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7697,7 +7719,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-316>
+          <http://model.geneontology.org/CHEBI_146131_RXN66-316>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_CHEBI_15379_RXN3O-227_SGD_PWY_YeastPathways_PWY3O-31704>
@@ -7705,7 +7727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7716,7 +7738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7730,7 +7752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7750,7 +7772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7766,7 +7788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7785,7 +7807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7805,7 +7827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7821,7 +7843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7841,7 +7863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7863,7 +7885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7879,7 +7901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7890,7 +7912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7904,11 +7926,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_146130>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102176> ;
@@ -7929,7 +7954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7942,7 +7967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7959,7 +7984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7970,7 +7995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7983,7 +8008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7999,7 +8024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8015,24 +8040,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_FERRICYTOCHROME-B5_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8040,7 +8062,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8e628c17-7080-4a0e-b881-644ec8e74be4_RXN66-317>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8051,7 +8073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8070,7 +8092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8081,7 +8103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8095,7 +8117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8111,7 +8133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8128,7 +8150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8139,23 +8161,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-130>
 ] .
 
-<http://model.geneontology.org/400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
@@ -8164,7 +8169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8183,7 +8188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8202,7 +8207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8221,7 +8226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8237,7 +8242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8249,7 +8254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8279,7 +8284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8296,7 +8301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8309,7 +8314,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FPPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_146130_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8324,7 +8359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8332,31 +8367,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FPPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_CHEBI_143575_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_58349_RXN66-314_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8371,7 +8398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8384,7 +8411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8395,7 +8422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8413,7 +8440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8443,7 +8470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8459,7 +8486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8470,23 +8497,12 @@
           <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002233_Red-NADPH-Hemoprotein-Reductases_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8497,7 +8513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8508,7 +8524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8519,7 +8535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8535,7 +8551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8554,7 +8570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8570,7 +8586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8584,7 +8600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8606,7 +8622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8622,7 +8638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8633,7 +8649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8647,7 +8663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8663,7 +8679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8674,7 +8690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8688,7 +8704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8704,7 +8720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8714,11 +8730,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15379_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_CHEBI_15378_RXN66-317_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8726,7 +8742,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN66-317>
+          <http://model.geneontology.org/CHEBI_15378_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8737,7 +8753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8756,7 +8772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8775,7 +8791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8791,7 +8807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8809,7 +8825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8824,7 +8840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8837,7 +8853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8868,7 +8884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8885,7 +8901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8912,7 +8928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8931,7 +8947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8947,7 +8963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8964,7 +8980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8984,7 +9000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -9000,7 +9016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9016,7 +9032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9030,7 +9046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9048,11 +9064,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_15377_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_CHEBI_146130_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9060,19 +9076,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_RXN66-315>
+          <http://model.geneontology.org/CHEBI_146130_RXN66-315>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002411_RXN66-318_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -9082,7 +9087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9101,7 +9106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9121,7 +9126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9137,7 +9142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9159,7 +9164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9175,7 +9180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9190,7 +9195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9206,7 +9211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9217,18 +9222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_635234a2-ce53-45b1-a716-7b83a0bce81e_RXN66-315_SGD_PWY_YeastPathways_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9243,7 +9237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9259,7 +9253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9282,7 +9276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9295,7 +9289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9306,7 +9300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -9319,7 +9313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9335,7 +9329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9354,7 +9348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9374,7 +9368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9386,11 +9380,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_FERRICYTOCHROME-B5_RXN66-316_SGD_PWY_YeastPathways_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9398,7 +9392,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/400b0e26-a014-4f59-8113-24f29e48fe4d_RXN66-316>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002233_CHEBI_15379_RXN3O-130_SGD_PWY_YeastPathways_PWY3O-31704>
@@ -9406,7 +9400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9421,7 +9415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9437,7 +9431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9455,7 +9449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9471,7 +9465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9485,7 +9479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9501,7 +9495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9515,7 +9509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9535,7 +9529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9548,7 +9542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9562,7 +9556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9582,7 +9576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9598,7 +9592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9614,7 +9608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9628,7 +9622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9644,7 +9638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-31723.ttl
+++ b/models/YeastPathways_PWY3O-31723.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -19,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,26 +342,26 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_FATTY-ACYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_33184_FATTY-ACYL-COA-SYNTHASE-RXN_SGD_PWY_YeastPathways_PWY3O-31723>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_CPLX-7627_FATTY-ACYL-COA-SYNTHASE-RXN_controller_BFO_0000051_SGD_S000001665_CPLX-7627_component_SGD_PWY_YeastPathways_PWY3O-31723>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acids biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-335.ttl
+++ b/models/YeastPathways_PWY3O-335.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetoin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,12 +287,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_15688_ACETOINDEHYDROG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15688> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22271> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -476,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -663,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -675,12 +692,15 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -692,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -799,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -859,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,18 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-335" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -917,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,11 +944,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +956,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17499_RXN-6081>
@@ -959,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,37 +1016,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22329> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_58476_ACETOLACTSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58476> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-2-acetolactate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22354> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1049,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,6 +1042,32 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15361_ACETOLACTSYN-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_58476_ACETOLACTSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58476> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-2-acetolactate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22354> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACETOINDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -1071,13 +1080,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_16583_RXN-6081> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15688_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1189,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1227,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1239,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,11 +1263,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_15688_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1275,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_15688_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY_YeastPathways_PWY3O-335>
@@ -1274,28 +1283,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/dc659465-4cf2-4d3f-adce-bc87d5acae32_ACETOINDEHYDROG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-335SmallMolecule22271> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1308,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,6 +1310,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_15688_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-335>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-335" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1330,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1363,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-335" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-351.ttl
+++ b/models/YeastPathways_PWY3O-351.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_SGD_S000006322_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -727,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -814,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,11 +946,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-351> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_SGD_S000006322_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-351> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +958,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
+          <http://model.geneontology.org/SGD_S000006322_CPLX3O-113_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5.3.1.23-RXN_RO_0002234_CHEBI_58548_5.3.1.23-RXN_SGD_PWY_YeastPathways_PWY3O-351>
@@ -955,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -969,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1287,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1320,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1375,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,11 +1432,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000006322>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1438,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,7 +1474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1517,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1544,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1595,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,13 +1621,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003785> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "methylthioribulose-1-phosphate dehydratase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1656,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1690,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1726,7 +1740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1737,6 +1751,15 @@
           <http://model.geneontology.org/5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000006322_CPLX3O-113_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006322> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
@@ -1745,7 +1768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1764,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1804,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1815,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1829,7 +1852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1860,7 +1883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1877,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1923,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1976,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1989,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2000,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2014,7 +2037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2042,7 +2065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2137,7 +2160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2153,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2164,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2178,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2216,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2230,7 +2253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2257,7 +2280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2274,7 +2297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,7 +2355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2346,7 +2369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2382,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2394,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2408,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2424,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2449,7 +2472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2468,7 +2491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2484,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2509,7 +2532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2525,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2562,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2579,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2596,24 +2619,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-351" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-351>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-351" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57844_R15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57844> ;
@@ -2624,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2640,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2670,7 +2682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2687,7 +2699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2700,11 +2712,11 @@
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "methylthioribose-1 P isomerase" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component> ;
+                <http://model.geneontology.org/SGD_S000006322_CPLX3O-113_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2720,7 +2732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,7 +2752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2763,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2791,7 +2803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2807,7 +2819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2824,7 +2836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2836,7 +2848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2856,7 +2868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2873,7 +2885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2886,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2903,7 +2915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2923,7 +2935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2939,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2953,7 +2965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2970,9 +2982,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_17509>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0071267>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2981,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2992,18 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-351" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3015,7 +3013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3026,12 +3024,26 @@
           <http://model.geneontology.org/MONOMER3O-175_3.1.3.77-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000050_YeastPathways_PWY3O-351/YeastPathways_PWY3O-351_SGD_PWY_YeastPathways_PWY3O-351>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-351" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000003785>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
         a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3043,7 +3055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3063,7 +3075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3082,7 +3094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3102,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3119,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3132,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3143,7 +3155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3166,7 +3178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3181,7 +3193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3197,7 +3209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3213,7 +3225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3230,7 +3242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3257,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3271,7 +3283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3282,21 +3294,12 @@
           <http://model.geneontology.org/YJR148W-MONOMER_R15-RXN_controller>
 ] .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002234_CHEBI_57844_R15-RXN_SGD_PWY_YeastPathways_PWY3O-351>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3307,7 +3310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3318,7 +3321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3332,7 +3335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3362,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3375,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3403,7 +3406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3420,7 +3423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3439,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3455,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3469,7 +3472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3485,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3505,7 +3508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3523,7 +3526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3539,7 +3542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3557,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,7 +3573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3587,7 +3590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3617,7 +3620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3630,7 +3633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3641,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3658,7 +3661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3680,7 +3683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3696,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3710,7 +3713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3730,7 +3733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3747,7 +3750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3760,7 +3763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3771,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3788,7 +3791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3804,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3821,7 +3824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3837,7 +3840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3851,7 +3854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,7 +3870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3878,7 +3881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3889,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3903,7 +3906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3922,7 +3925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3938,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3952,7 +3955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3968,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3982,7 +3985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4004,7 +4007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4020,7 +4023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4035,7 +4038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4054,7 +4057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4073,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -4086,7 +4089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4099,7 +4102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-351" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-355.ttl
+++ b/models/YeastPathways_PWY3O-355.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -379,7 +379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -853,7 +853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,7 +1294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1398,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1412,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1581,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "stearate biosynthesis III (fungi) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,7 +1671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1690,7 +1690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1733,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1747,7 +1747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1780,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1797,7 +1797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1816,7 +1816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1835,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1844,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1858,7 +1858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1919,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2020,7 +2020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2080,7 +2080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2096,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2177,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2224,7 +2224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2294,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-3827.ttl
+++ b/models/YeastPathways_PWY3O-3827.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glucose-6-phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-4.ttl
+++ b/models/YeastPathways_PWY3O-4.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "carnitine shuttle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,24 +613,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4Protein51238> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_PWY_YeastPathways_PWY3O-4>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -640,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,6 +640,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4/YeastPathways_PWY3O-4>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARNITINE-O-ACETYLTRANSFERASE-RXN_BFO_0000050_YeastPathways_PWY3O-4/YeastPathways_PWY3O-4_SGD_PWY_YeastPathways_PWY3O-4>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-402.ttl
+++ b/models/YeastPathways_PWY3O-402.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,13 +37,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47125> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002413_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -53,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,17 +75,6 @@
           <http://model.geneontology.org/CHEBI_58628_2.7.1.152-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,6 +117,20 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://identifiers.org/sgd/S000002424>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_CHEBI_52965_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN-7162>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -126,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,17 +244,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation 'ATP + phytate &rarr; ADP + 4- or 6-diphosphoinositol pentakisphosphate' 'null' '4- or 6-diphosphoinositol pentakisphosphate + ATP &rarr; [PP]<sub>2</sub>-IP<sub>4</sub> + ADP' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002411_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002413_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-258> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -258,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,16 +401,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -406,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,35 +433,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,17 +469,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+          "Provides Input For Rule. The relation '4- or 6-diphosphoinositol pentakisphosphate + ATP &rarr; [PP]<sub>2</sub>-IP<sub>4</sub> + ADP' 'null' '[PP]<sub>2</sub>-IP<sub>4</sub> + H<sub>2</sub>O &rarr; diphosphoinositol pentakisphosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002413_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -500,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -585,18 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -611,11 +594,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47008> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_18348_3.1.4.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_18348> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -633,13 +633,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16322_RXN-7184> , <http://model.geneontology.org/CHEBI_30616_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/CHEBI_14178_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller> , <http://model.geneontology.org/MONOMER3O-205_RXN-4941_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,23 +685,23 @@
           <http://model.geneontology.org/CHEBI_30616_2.7.1.151-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002233_CHEBI_30616_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_CHEBI_53064_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,14 +726,25 @@
           <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-785_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_52965_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-205_RXN-4941_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000002424> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "inositol-pentakisphosphate kinase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -834,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -847,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -901,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -914,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1133,18 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1175,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,15 +1203,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58628_2.7.1.152-RXN> , <http://model.geneontology.org/CHEBI_30616_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143> , <http://model.geneontology.org/CHEBI_456216_RXN3O-143> ;
+                <http://model.geneontology.org/CHEBI_52965_RXN3O-143> , <http://model.geneontology.org/CHEBI_456216_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-143_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-786> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1227,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1272,11 +1272,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_52965_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1284,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143>
+          <http://model.geneontology.org/CHEBI_52965_RXN3O-143>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1295,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,40 +1306,23 @@
           <http://model.geneontology.org/RXN-4941>
 ] .
 
-<http://model.geneontology.org/28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4- or 6-diphosphoinositol pentakisphosphate" ;
+<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002234_CHEBI_58628_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1364,16 +1347,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47224> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-143>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1384,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,15 +1372,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9819_BFO_0000066_reaction_RXN3O-9819_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1414,7 +1391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1447,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1494,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1533,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1623,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1637,7 +1614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1653,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1720,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1747,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1761,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1810,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1821,18 +1798,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_52965>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_15377_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1843,18 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1879,7 +1848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1893,16 +1862,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_17815>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_62919>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-786>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1913,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1926,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1936,11 +1897,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_52965_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1909,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-143> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143>
+          <http://model.geneontology.org/CHEBI_52965_RXN3O-143>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1959,7 +1920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2006,15 +1967,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58130_RXN-7163> , <http://model.geneontology.org/CHEBI_30616_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN3O-258> , <http://model.geneontology.org/28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258> ;
+                <http://model.geneontology.org/CHEBI_53064_RXN3O-258> , <http://model.geneontology.org/CHEBI_456216_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-258_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9819> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2031,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2047,7 +2008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,23 +2074,12 @@
           <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002234_CHEBI_17815_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2154,7 +2104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,11 +2119,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_18348_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,30 +2131,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN>
+          <http://model.geneontology.org/CHEBI_18348_3.1.4.11-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-64_RXN-4941_controller_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-258>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2215,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2223,8 +2151,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002333_MONOMER3O-64_RXN-4941_controller_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_53064_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_14178>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2234,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2278,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,17 +2256,6 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-786>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_30616_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2323,13 +2265,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47198> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_30616_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2339,7 +2292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,6 +2303,34 @@
           <http://model.geneontology.org/RXN-7163>
 ] .
 
+<http://model.geneontology.org/CHEBI_52965_RXN3O-9819>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_52965> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_52965_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2358,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2369,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2378,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2389,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2414,6 +2395,23 @@
 
 <http://purl.obolibrary.org/obo/GO_0004435>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_14178_RXN-4941>
+        a       <http://purl.obolibrary.org/obo/CHEBI_14178> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2423,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2442,7 +2440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2461,7 +2459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2492,7 +2490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2508,7 +2506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,7 +2536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2563,7 +2561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2579,7 +2577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2598,7 +2596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2618,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2634,7 +2632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2653,7 +2651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2667,12 +2665,23 @@
 <http://identifiers.org/sgd/S000005689>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002413_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002413_RXN-7184_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2686,7 +2695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2736,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2753,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2774,11 +2783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_53064_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,7 +2795,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258>
+          <http://model.geneontology.org/CHEBI_53064_RXN3O-258>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7184_location_lociGO_0005829>
@@ -2794,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2806,7 +2815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2825,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2840,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2856,7 +2865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,15 +2885,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9819_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> , <http://model.geneontology.org/4831da01-1177-4e4a-9013-da92e8e81534_RXN3O-258> ;
+                <http://model.geneontology.org/CHEBI_53064_RXN3O-258> , <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819> , <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+                <http://model.geneontology.org/CHEBI_52965_RXN3O-9819> , <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-786> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2920,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2933,7 +2942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2947,7 +2956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2977,7 +2986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2996,7 +3005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3012,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3026,7 +3035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3045,7 +3054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3072,7 +3081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3083,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3096,7 +3105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3108,11 +3117,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_CHEBI_62919_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3120,7 +3129,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786>
+          <http://model.geneontology.org/CHEBI_62919_RXN3O-786>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_CHEBI_456216_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
@@ -3128,7 +3137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3139,7 +3148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3153,7 +3162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3169,26 +3178,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3198,7 +3190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3214,7 +3206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3229,24 +3221,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47008> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002411_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3259,7 +3240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,7 +3256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3286,7 +3267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3300,7 +3281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3311,6 +3292,23 @@
           <http://model.geneontology.org/reaction_RXN-7162_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/CHEBI_53064_RXN3O-258>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_53064> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4- or 6-diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN3O-143>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3320,7 +3318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3337,7 +3335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3350,9 +3348,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_52965_RXN3O-143>
+        a       <http://purl.obolibrary.org/obo/CHEBI_52965> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3362,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,7 +3396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3402,11 +3417,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_CHEBI_53064_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3414,7 +3429,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-258> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258>
+          <http://model.geneontology.org/CHEBI_53064_RXN3O-258>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000066_reaction_RXN-7184_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-402>
@@ -3422,7 +3437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3433,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3448,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3465,7 +3480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3481,7 +3496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3491,23 +3506,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_RXN-7163>
 ] .
-
-<http://model.geneontology.org/d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-7163>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0035299> ;
@@ -3528,7 +3526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3544,7 +3542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3555,12 +3553,6 @@
           <http://model.geneontology.org/CHEBI_57627_2.7.1.151-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/CHEBI_16322_RXN-7162>
         a       <http://purl.obolibrary.org/obo/CHEBI_16322> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3570,11 +3562,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47063> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_62919_RXN3O-786>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_62919> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3586,7 +3595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3602,38 +3611,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/RXN3O-785>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008486> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate + H<sub>2</sub>O &rarr; phytate + phosphate" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58130_RXN3O-785> , <http://model.geneontology.org/CHEBI_43474_RXN3O-785> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-785_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/2.7.1.152-RXN> , <http://model.geneontology.org/RXN3O-258> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction46990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.1.151-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3644,13 +3626,51 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47125> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/RXN3O-785>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008486> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate + H<sub>2</sub>O &rarr; phytate + phosphate" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/YeastPathways_PWY3O-402/YeastPathways_PWY3O-402> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_62919_RXN3O-786> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/CHEBI_58130_RXN3O-785> , <http://model.geneontology.org/CHEBI_43474_RXN3O-785> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-785_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/2.7.1.152-RXN> , <http://model.geneontology.org/RXN3O-258> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction46990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_CHEBI_62919_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3660,7 +3680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3680,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3693,21 +3713,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002234_CHEBI_456216_RXN-7162_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3721,7 +3738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3732,23 +3749,12 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-9819>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_28dd3f27-e588-4eba-b67a-f72aff1f9408_RXN3O-258_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002413_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3759,7 +3765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3767,17 +3773,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+          "Provides Input For Rule. The relation 'ATP + 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate &rarr; ADP + [PP]<sub>2</sub>-IP<sub>4</sub>' 'null' '[PP]<sub>2</sub>-IP<sub>4</sub> + H<sub>2</sub>O &rarr; diphosphoinositol pentakisphosphate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002411_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002413_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-143> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -3789,18 +3795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3814,7 +3809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3828,7 +3823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3847,7 +3842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3863,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3876,7 +3871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3893,7 +3888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3912,7 +3907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3927,11 +3922,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_CHEBI_62919_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3939,7 +3934,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-785> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7eb3767d-f15d-4674-ac34-220588968aad_RXN3O-786>
+          <http://model.geneontology.org/CHEBI_62919_RXN3O-786>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3950,7 +3945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3969,7 +3964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3981,13 +3976,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-205_2.7.1.152-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000002424> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "inositol-pentakisphosphate kinase [multifunctional]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4000,7 +3995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4011,7 +4006,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002413_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4021,11 +4027,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_456216_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_14178_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4033,7 +4039,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-4941> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_RXN-4941>
+          <http://model.geneontology.org/CHEBI_14178_RXN-4941>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_16322>
@@ -4047,35 +4053,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/bee427d1-2ed5-4e43-b946-6ecfe35a1408_RXN3O-143>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-4941_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4090,7 +4079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4103,18 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4123,19 +4101,22 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_53064>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" , "Provides Input For Rule. The relation '[PP]<sub>2</sub>-IP<sub>4</sub> + H<sub>2</sub>O &rarr; diphosphoinositol pentakisphosphate + phosphate' 'null' 'diphosphoinositol pentakisphosphate + H<sub>2</sub>O &rarr; phytate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002411_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002413_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4147,7 +4128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4160,7 +4141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4177,7 +4158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4190,7 +4171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4204,7 +4185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4226,7 +4207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4242,7 +4223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4253,7 +4234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4267,7 +4248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4286,7 +4267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,12 +4281,23 @@
 <http://identifiers.org/sgd/S000002580>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002413_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_BFO_0000050_YeastPathways_PWY3O-402/YeastPathways_PWY3O-402_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4316,7 +4308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4327,13 +4319,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_18348>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4344,7 +4339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4365,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4381,7 +4376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4392,12 +4387,23 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-7163>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_14178_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002233_CHEBI_57627_2.7.1.151-RXN_SGD_PWY_YeastPathways_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4412,7 +4418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4425,7 +4431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4436,7 +4442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4452,7 +4458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4468,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4482,7 +4488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4498,7 +4504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4513,7 +4519,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/47b12746-a63f-42ab-9dca-630abdc6ab7c_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_18348_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4523,7 +4529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4531,12 +4537,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002411_RXN3O-785_SGD_PWY_YeastPathways_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_CHEBI_18348_3.1.4.11-RXN_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4551,17 +4557,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-786_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-786> , <http://model.geneontology.org/3eb7d37f-ba2e-4cad-8430-6877652317ed_RXN3O-143> ;
+                <http://model.geneontology.org/CHEBI_52965_RXN3O-143> , <http://model.geneontology.org/CHEBI_15377_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786> , <http://model.geneontology.org/CHEBI_43474_RXN3O-786> ;
+                <http://model.geneontology.org/CHEBI_62919_RXN3O-786> , <http://model.geneontology.org/CHEBI_43474_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-785> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4577,7 +4583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4595,7 +4601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4610,7 +4616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4621,23 +4627,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/582be5db-88b3-43f0-b55c-056f4e0e0f94_RXN3O-786>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_2.7.1.127-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4647,7 +4636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4667,7 +4656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4679,11 +4668,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_CHEBI_52965_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4691,7 +4680,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d77dbe09-0e3a-4195-ad92-9eeb5663f146_RXN3O-9819>
+          <http://model.geneontology.org/CHEBI_52965_RXN3O-9819>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002233_CHEBI_58628_2.7.1.152-RXN_SGD_PWY_YeastPathways_PWY3O-402>
@@ -4699,7 +4688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4717,7 +4706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4730,7 +4719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4742,7 +4731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4772,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4788,7 +4777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4807,7 +4796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4823,7 +4812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4834,7 +4823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4848,7 +4837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4866,7 +4855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4879,7 +4868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4893,7 +4882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4909,7 +4898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4923,7 +4912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4942,7 +4931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4958,7 +4947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4972,7 +4961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4988,7 +4977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -5005,7 +4994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5023,11 +5012,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_CHEBI_456216_RXN-4941_SGD_PWY_YeastPathways_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5035,7 +5024,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-4941> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6ec1e05b-74d8-4177-89e0-d9b09501b9ae_RXN-4941>
+          <http://model.geneontology.org/CHEBI_456216_RXN-4941>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_CHEBI_30616_RXN3O-9819_SGD_PWY_YeastPathways_PWY3O-402>
@@ -5043,7 +5032,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_CHEBI_62919_RXN3O-786_SGD_PWY_YeastPathways_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -5057,7 +5057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5075,7 +5075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5088,7 +5088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5097,7 +5097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -5108,7 +5108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5117,7 +5117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-402" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4031.ttl
+++ b/models/YeastPathways_PWY3O-4031.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,28 +63,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -108,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -182,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,6 +182,9 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/3bc195d4-c568-46ce-9a47-de7c19b21eea_RXN-7668>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -211,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,11 +239,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_74da55fb-2755-46e2-943f-7e672db80f5b_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +251,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668>
+          <http://model.geneontology.org/74da55fb-2755-46e2-943f-7e672db80f5b_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -276,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -400,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -488,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +518,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7669_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3428e415-2a26-4483-9729-9f175934f517_RXN-7668> ;
+                <http://model.geneontology.org/3bc195d4-c568-46ce-9a47-de7c19b21eea_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_24384_RXN-7669> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -540,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -659,7 +645,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_7b866339-ddaf-4bc6-85ad-e25289ecfc26_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -763,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,11 +781,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_7b866339-ddaf-4bc6-85ad-e25289ecfc26_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +793,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668>
+          <http://model.geneontology.org/7b866339-ddaf-4bc6-85ad-e25289ecfc26_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -807,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -849,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -877,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -906,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -916,11 +913,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_3428e415-2a26-4483-9729-9f175934f517_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_3bc195d4-c568-46ce-9a47-de7c19b21eea_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +925,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7669> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3428e415-2a26-4483-9729-9f175934f517_RXN-7668>
+          <http://model.geneontology.org/3bc195d4-c568-46ce-9a47-de7c19b21eea_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -939,7 +936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -966,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,17 +987,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_3428e415-2a26-4483-9729-9f175934f517_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1013,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1074,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1173,7 +1159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,6 +1210,17 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_74da55fb-2755-46e2-943f-7e672db80f5b_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
@@ -1232,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1287,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,23 +1307,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_CHEBI_58223_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_3bc195d4-c568-46ce-9a47-de7c19b21eea_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_CHEBI_58223_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,15 +1387,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/3428e415-2a26-4483-9729-9f175934f517_RXN-7668>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002333_MONOMER3O-4031_RXN-7667_controller_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,9 +1482,6 @@
           <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
 ] .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
@@ -1499,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1555,22 +1546,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://identifiers.org/sgd/S000001518>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1582,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1672,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1687,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1732,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,11 +1725,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/74da55fb-2755-46e2-943f-7e672db80f5b_RXN-7668>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1762,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1782,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1820,7 +1814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1850,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1889,7 +1883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1909,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1936,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,7 +1949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1995,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2007,7 +2001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,9 +2021,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7668_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6fa2057f-1500-4df2-9ae3-7a61e76f2d92_RXN-7668> , <http://model.geneontology.org/CHEBI_58885_RXN-7668> ;
+                <http://model.geneontology.org/CHEBI_58885_RXN-7668> , <http://model.geneontology.org/7b866339-ddaf-4bc6-85ad-e25289ecfc26_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668> , <http://model.geneontology.org/CHEBI_58223_RXN-7668> ;
+                <http://model.geneontology.org/74da55fb-2755-46e2-943f-7e672db80f5b_RXN-7668> , <http://model.geneontology.org/CHEBI_58223_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR258W-MONOMER_RXN-7668_controller> , <http://model.geneontology.org/YFR015C-MONOMER_RXN-7668_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2037,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2052,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2069,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2085,7 +2079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,7 +2095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2118,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,12 +2123,29 @@
           <http://model.geneontology.org/CHEBI_46398_GLUC1PURIDYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/7b866339-ddaf-4bc6-85ad-e25289ecfc26_RXN-7668>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_BFO_0000066_reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2145,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2156,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2173,7 +2184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2189,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2202,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2257,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2281,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2292,18 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_38dbd168-e1df-4819-9a2d-5db47f23fb71_RXN-7668_SGD_PWY_YeastPathways_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2317,7 +2317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2342,7 +2342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2358,7 +2358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2369,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2398,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4105.ttl
+++ b/models/YeastPathways_PWY3O-4105.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,23 +820,23 @@
           <http://model.geneontology.org/CPLX3O-118_RXN3O-4133_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-4141_BFO_0000050_YeastPathways_PWY3O-4105/YeastPathways_PWY3O-4105_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "valine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1087,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1151,18 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1173,7 +1162,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002333_YDL168W-MONOMER_RXN3O-4141_controller_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,23 +1201,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_48943>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-4141_RO_0002233_CHEBI_57945_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4133_RO_0002413_RXN3O-4141_SGD_PWY_YeastPathways_PWY3O-4105>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1398,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,7 +1464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1494,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4106.ttl
+++ b/models/YeastPathways_PWY3O-4106.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway IV (from nicotinamide riboside) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -763,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -797,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -894,30 +894,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106BiochemicalReaction69520> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69466> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -928,11 +911,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69509> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69466> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 

--- a/models/YeastPathways_PWY3O-4107.ttl
+++ b/models/YeastPathways_PWY3O-4107.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -13,11 +13,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_33c262d8-21f7-4c8f-982d-d007db389321_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025>
+          <http://model.geneontology.org/33c262d8-21f7-4c8f-982d-d007db389321_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -180,24 +180,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-4107" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -207,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -422,11 +411,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +423,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025>
+          <http://model.geneontology.org/CHEBI_83767_RXN-15025>
 ] .
 
 <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
@@ -442,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,9 +476,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/33c262d8-21f7-4c8f-982d-d007db389321_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_5738_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -497,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -550,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,23 +614,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_456215_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -649,23 +627,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004516>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/3f096c82-36cb-4700-9699-1356b7da2269_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -675,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -845,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,6 +835,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58359>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_5738_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -882,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -906,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1064,7 +1036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1196,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway V (PNC V cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1348,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1440,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1514,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1564,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1578,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1623,7 +1595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1657,12 +1629,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_5738>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1680,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1697,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,28 +1708,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69850> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/212517d5-c9a5-471d-89ac-8da42b30ea64_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1766,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,12 +1735,23 @@
           <http://model.geneontology.org/RXN-15025>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_33c262d8-21f7-4c8f-982d-d007db389321_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000050_YeastPathways_PWY3O-4107/YeastPathways_PWY3O-4107_SGD_PWY_YeastPathways_PWY3O-4107>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1797,11 +1766,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule70079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/33c262d8-21f7-4c8f-982d-d007db389321_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1810,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1827,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,7 +1832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1909,11 +1895,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_5738_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_5738> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_NICONUCADENYLYLTRAN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -1924,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1951,11 +1954,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_5738_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1966,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_83767_RXN-15025>
+          <http://model.geneontology.org/CHEBI_5738_RXN-15025>
 ] .
 
 <http://identifiers.org/sgd/S000005735>
@@ -1977,7 +1980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2007,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2023,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2069,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,7 +2106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2119,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2168,7 +2171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2193,7 +2196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,7 +2215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2228,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2243,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2259,7 +2262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2279,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2292,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2315,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2331,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2345,7 +2348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,7 +2367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2383,7 +2386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2416,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2432,7 +2435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2473,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2484,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4108.ttl
+++ b/models/YeastPathways_PWY3O-4108.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tyrosine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -555,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,17 +880,6 @@
           <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58315_TYROSINE-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58315> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -900,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,12 +897,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YGL256W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,7 +950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1035,17 +1035,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_36242>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1055,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,6 +1055,17 @@
           <http://model.geneontology.org/YMR303C-MONOMER_RXN3O-4113_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002413_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
@@ -1074,7 +1074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,17 +1134,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_4.1.1.80-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57540_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/4.1.1.80-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0050546> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1163,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1176,7 +1165,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002234_CHEBI_57540_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1275,26 +1275,26 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_4.1.1.80-RXN_RO_0002234_CHEBI_16526_4.1.1.80-RXN_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,16 +1499,24 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4108" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4113> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1518,7 +1526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1546,31 +1554,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002233_CHEBI_57945_RXN3O-4113_SGD_PWY_YeastPathways_PWY3O-4108> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4113> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_RXN3O-4113>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_58315_RXN3O-4157_SGD_PWY_YeastPathways_PWY3O-4108>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4108" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-4113_RO_0002333_YMR083W-MONOMER_RXN3O-4113_controller_SGD_PWY_YeastPathways_PWY3O-4108>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1584,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1640,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1725,7 +1725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-4109.ttl
+++ b/models/YeastPathways_PWY3O-4109.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "isoleucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,7 +1352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1382,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1566,7 +1566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1611,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1680,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1823,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4112.ttl
+++ b/models/YeastPathways_PWY3O-4112.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -573,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,17 +807,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
@@ -826,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,6 +826,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4112/YeastPathways_PWY3O-4112>
 ] .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001251> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1153,7 +1153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "leucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1273,7 +1273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1301,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,7 +1356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1375,7 +1375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,18 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1424,13 +1413,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4112Protein49082> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002233_CHEBI_16810_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY_YeastPathways_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1440,7 +1440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-4115.ttl
+++ b/models/YeastPathways_PWY3O-4115.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -409,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -902,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1028,7 +1028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1055,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1117,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1176,7 +1176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1237,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1428,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1437,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1450,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1466,7 +1466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1542,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1558,7 +1558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,19 +1644,19 @@
           <http://model.geneontology.org/CHEBI_18005_RXN-10814>
 ] .
 
+<http://identifiers.org/sgd/S000001179>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-10814_RO_0002333_YIL116W-MONOMER_RXN-10814_controller_SGD_PWY_YeastPathways_PWY3O-4115>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000001179>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_RXN3O-163>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -1667,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1703,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1725,7 +1725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1763,7 +1763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1808,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,7 +1824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1843,7 +1843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1923,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1948,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1962,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1981,7 +1981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2001,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2036,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2081,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,7 +2100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,7 +2119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2132,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2145,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2162,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4120.ttl
+++ b/models/YeastPathways_PWY3O-4120.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,9 +181,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -192,23 +204,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN3O-4157_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15361_RXN3O-4157>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,7 +581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -718,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -867,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -904,7 +904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1008,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tyrosine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1175,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1250,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1341,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,9 +1366,6 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004665>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
@@ -1377,7 +1374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,12 +1385,15 @@
           <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004665>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_PWY_YeastPathways_PWY3O-4120>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1490,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1506,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-4153.ttl
+++ b/models/YeastPathways_PWY3O-4153.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -892,7 +892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1014,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1055,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,7 +1087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1248,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1262,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1315,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1326,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1368,7 +1368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1484,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1524,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1540,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-4158.ttl
+++ b/models/YeastPathways_PWY3O-4158.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_2bda666c-5767-4ce7-b8b4-f27232c99c8a_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,23 +778,6 @@
           <http://model.geneontology.org/RXN-5721>
 ] .
 
-<http://model.geneontology.org/b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -792,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -853,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of NAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,6 +964,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_5738>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -978,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1054,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,23 +1144,12 @@
           <http://model.geneontology.org/CHEBI_29888_NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002411_2.7.7.1-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1205,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1368,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1384,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1412,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1483,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1523,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1592,7 +1578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1681,6 +1667,32 @@
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "nicotinate phosphoribosyl transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35528> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1690,7 +1702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1701,21 +1713,6 @@
           <http://model.geneontology.org/reaction_RXN-5721_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "nicotinate phosphoribosyl transferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35528> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -1724,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,17 +1732,6 @@
           <http://model.geneontology.org/CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-8443_BFO_0000066_reaction_RXN-8443_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1754,7 +1740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1787,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1812,7 +1798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1872,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1883,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1932,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1945,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1980,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2002,18 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2028,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2039,9 +2014,6 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -2050,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,6 +2033,20 @@
           <http://model.geneontology.org/CHEBI_15927_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -2069,7 +2055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,7 +2103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2169,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2191,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2261,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2274,7 +2260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2308,7 +2294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2324,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2338,7 +2324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,7 +2347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2377,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2391,7 +2377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2411,7 +2397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2427,7 +2413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2447,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2460,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2474,7 +2460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2488,7 +2474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2503,11 +2489,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_5738_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2515,7 +2501,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_83767_RXN-15025>
+          <http://model.geneontology.org/CHEBI_5738_RXN-15025>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002333_MONOMER3O-17_ARYLFORMAMIDASE-RXN_controller_SGD_PWY_YeastPathways_PWY3O-4158>
@@ -2523,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2548,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2578,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2592,7 +2578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2614,7 +2600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2634,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2650,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2678,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2692,7 +2678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2711,7 +2697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,7 +2713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2745,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2758,7 +2744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2769,7 +2755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2783,7 +2769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2797,7 +2783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2813,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2824,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2835,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2844,9 +2830,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2858,7 +2853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2869,21 +2864,12 @@
           <http://model.geneontology.org/CHEBI_57502_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RIBOSYLNICOTINAMIDE-KINASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002234_CHEBI_29985_NAD-SYNTH-GLN-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2898,7 +2884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2914,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2926,7 +2912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2945,7 +2931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2964,7 +2950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3006,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3024,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3040,7 +3026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3059,7 +3045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3078,7 +3064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3111,7 +3097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3130,7 +3116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3162,7 +3148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3178,7 +3164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,7 +3183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3213,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3224,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3242,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3258,7 +3244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3274,7 +3260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3288,7 +3274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3307,7 +3293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3323,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3340,7 +3326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3351,6 +3337,17 @@
           <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN0-7092>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3360,24 +3357,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_BFO_0000066_reaction_NICOTINAMID-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3387,7 +3373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3407,7 +3393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3420,7 +3406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3438,7 +3424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3455,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3468,7 +3454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3483,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3496,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3510,7 +3496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3529,7 +3515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3552,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3583,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3605,7 +3591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3620,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3633,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3644,7 +3630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3657,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3670,7 +3656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3681,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3693,7 +3679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3709,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3717,28 +3703,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004731>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3748,7 +3712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3759,12 +3723,34 @@
           <http://model.geneontology.org/CHEBI_17154_RXN0-7092>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_16988_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_RO_0002233_CHEBI_16675_RXN-5721_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3777,7 +3763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3794,24 +3780,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35318> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3821,7 +3796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3840,7 +3815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3851,12 +3826,23 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-8441>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002233_CHEBI_30616_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3871,7 +3857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3888,7 +3874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3913,7 +3899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3926,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3943,7 +3929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3965,7 +3951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3981,7 +3967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3992,7 +3978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4003,7 +3989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4017,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4031,7 +4017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4050,7 +4036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4070,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4083,7 +4069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4100,7 +4086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4115,11 +4101,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4127,7 +4113,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025>
+          <http://model.geneontology.org/CHEBI_83767_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004502>
@@ -4138,7 +4124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4149,7 +4135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4163,7 +4149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4182,7 +4168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4193,19 +4179,19 @@
           <http://model.geneontology.org/YJL060W-MONOMER_ARYLFORMAMIDASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_994>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_994>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN3O-205>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004731> ;
@@ -4228,7 +4214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4247,7 +4233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4263,7 +4249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4277,7 +4263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4303,7 +4289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4321,7 +4307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4334,7 +4320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4349,7 +4335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,24 +4352,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35543> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4393,7 +4368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4404,6 +4379,17 @@
           <http://model.geneontology.org/ARYLFORMAMIDASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57720_RXN0-7092>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57720> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4413,7 +4399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4426,7 +4412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4453,7 +4439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4470,7 +4456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4486,7 +4472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4508,7 +4494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4528,7 +4514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4541,7 +4527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4552,7 +4538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4566,7 +4552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4586,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4599,7 +4585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4610,7 +4596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4624,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4638,7 +4624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4649,7 +4635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4663,7 +4649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4682,7 +4668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4701,7 +4687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4720,7 +4706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4740,7 +4726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4753,7 +4739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4764,7 +4750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4778,7 +4764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4792,7 +4778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,7 +4797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4831,7 +4817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4848,7 +4834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4861,18 +4847,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/2bda666c-5767-4ce7-b8b4-f27232c99c8a_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4886,7 +4889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4905,7 +4908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4924,7 +4927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4944,7 +4947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4971,7 +4974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4990,7 +4993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5005,7 +5008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5021,7 +5024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5037,7 +5040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5051,7 +5054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5071,7 +5074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5084,7 +5087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5095,7 +5098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5104,7 +5107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5118,7 +5121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5137,7 +5140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5157,7 +5160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5170,7 +5173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5181,7 +5184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5192,7 +5195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5203,7 +5206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5214,7 +5217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5228,7 +5231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5244,7 +5247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5255,7 +5258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5270,7 +5273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5286,7 +5289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5300,7 +5303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5316,30 +5319,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.7.7.1-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-8441>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5350,7 +5334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5360,13 +5344,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002233_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.7.7.1-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" , "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002413_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5388,7 +5391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5404,7 +5407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5415,7 +5418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5426,7 +5429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5437,7 +5440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5451,7 +5454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5467,7 +5470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5481,7 +5484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5500,7 +5503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5511,7 +5514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5531,7 +5534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5550,7 +5553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5569,7 +5572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5582,7 +5585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5597,7 +5600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5613,7 +5616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5632,7 +5635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5643,12 +5646,23 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_5738_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-214_BFO_0000050_YeastPathways_PWY3O-4158/YeastPathways_PWY3O-4158_SGD_PWY_YeastPathways_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5659,7 +5673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5671,7 +5685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5690,7 +5704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5711,7 +5725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5728,7 +5742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5755,7 +5769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5782,7 +5796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5798,7 +5812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5821,13 +5835,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5837,7 +5860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5848,15 +5871,6 @@
           <http://model.geneontology.org/NAD-SYNTH-GLN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_1.13.11.6-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -5865,7 +5879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5881,7 +5895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5892,7 +5906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5901,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5914,7 +5928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5939,7 +5953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5959,7 +5973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5986,7 +6000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5999,7 +6013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6014,7 +6028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6027,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6047,7 +6061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6066,7 +6080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6086,7 +6100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6103,7 +6117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6116,7 +6130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6130,7 +6144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6150,7 +6164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6166,7 +6180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6186,7 +6200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6199,7 +6213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6210,7 +6224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6221,7 +6235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6235,7 +6249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6254,7 +6268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6284,7 +6298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6301,7 +6315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6314,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6325,7 +6339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6338,7 +6352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6355,7 +6369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6374,7 +6388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6394,11 +6408,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35264> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_5738_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_5738> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6411,7 +6442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6428,7 +6459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6444,7 +6475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6463,7 +6494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6483,28 +6514,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35385> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6517,7 +6531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6533,7 +6547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6552,7 +6566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6572,7 +6586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6585,7 +6599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6596,7 +6610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6607,7 +6621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6618,7 +6632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6629,7 +6643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6641,7 +6655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6661,7 +6675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6680,7 +6694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6691,23 +6705,6 @@
           <http://model.geneontology.org/NICOTINATEPRIBOSYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35814> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_43474_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6717,11 +6714,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35264> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_58349_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35814> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6732,7 +6746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6749,7 +6763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6765,7 +6779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6781,7 +6795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6801,7 +6815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6815,7 +6829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6831,7 +6845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6845,7 +6859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6856,7 +6870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6867,7 +6881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6881,7 +6895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6900,7 +6914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6922,7 +6936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6937,7 +6951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6953,7 +6967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6975,7 +6989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6995,7 +7009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7011,7 +7025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7030,7 +7044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7046,7 +7060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7063,7 +7077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7079,7 +7093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7093,7 +7107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7109,7 +7123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7120,7 +7134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7131,7 +7145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7142,7 +7156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7156,7 +7170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7172,7 +7186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7186,7 +7200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7202,7 +7216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7213,7 +7227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7225,7 +7239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7244,7 +7258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7267,7 +7281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7282,7 +7296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7295,7 +7309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7309,7 +7323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7325,7 +7339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7348,7 +7362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7361,7 +7375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7375,7 +7389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7391,7 +7405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7402,7 +7416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7416,7 +7430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7431,9 +7445,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_NAD-SYNTH-GLN-RXN> , <http://model.geneontology.org/2bda666c-5767-4ce7-b8b4-f27232c99c8a_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fe18d5c9-11d2-4f2f-95df-f96e0d6aa8b0_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_5738_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7441,7 +7455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7454,7 +7468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7485,7 +7499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7501,7 +7515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7514,7 +7528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7530,7 +7544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7549,7 +7563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7565,7 +7579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7579,7 +7593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7591,7 +7605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7610,7 +7624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7633,7 +7647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7649,7 +7663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7660,17 +7674,6 @@
           <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '2-amino-3-carboxymuconate-6-semialdehyde &rarr; quinolinate + H<sub>2</sub>O' 'null' 'CO<SUB>2</SUB> + &beta;-nicotinate D-ribonucleotide + diphosphate &larr; 5-phospho-&alpha;-D-ribose 1-diphosphate + quinolinate + 2 H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
@@ -7679,7 +7682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7699,7 +7702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7716,7 +7719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7729,7 +7732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7743,7 +7746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7775,7 +7778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7791,7 +7794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7809,7 +7812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7825,7 +7828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7844,7 +7847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7860,7 +7863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7871,7 +7874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7880,7 +7883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7895,7 +7898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7914,7 +7917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7933,7 +7936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7948,11 +7951,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_2bda666c-5767-4ce7-b8b4-f27232c99c8a_RXN-15025_SGD_PWY_YeastPathways_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7960,7 +7963,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b7b3766d-8da8-449f-a3d0-49671dbec633_RXN-15025>
+          <http://model.geneontology.org/2bda666c-5767-4ce7-b8b4-f27232c99c8a_RXN-15025>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
@@ -7972,7 +7975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7999,7 +8002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8012,7 +8015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8027,7 +8030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8040,7 +8043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8051,7 +8054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8065,7 +8068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8083,7 +8086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8102,7 +8105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8132,7 +8135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8148,7 +8151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8167,7 +8170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8183,7 +8186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8194,7 +8197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8208,7 +8211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8224,7 +8227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8239,7 +8242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8254,7 +8257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-4300.ttl
+++ b/models/YeastPathways_PWY3O-4300.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,7 +99,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,19 +154,19 @@
           <http://model.geneontology.org/CHEBI_57540_RXN66-3>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN66-3_BFO_0000066_reaction_RXN66-3_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57945_ALCOHOL-DEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -749,23 +749,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_RXN66-3_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ethanol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -867,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1084,12 +1084,12 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,16 +1114,20 @@
           <http://model.geneontology.org/CHEBI_57945_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETATE--COA-LIGASE-RXN_RO_0002233_CHEBI_57287_ACETATE--COA-LIGASE-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000050> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetyl CoA synthetase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-4300" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4300Protein25814> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/RXN66-3>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1142,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1158,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,20 +1173,16 @@
           <http://model.geneontology.org/CHEBI_456215_ACETATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/YAL054C-MONOMER_ACETATE--COA-LIGASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000050> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetyl CoA synthetase" ;
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002234_CHEBI_15343_ALCOHOL-DEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-4300>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4300Protein25814> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004143>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1215,7 +1215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1249,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1304,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1408,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1529,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1568,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-440.ttl
+++ b/models/YeastPathways_PWY3O-440.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,13 +50,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/CHEBI_15688_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,13 +69,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004034>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
@@ -87,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,6 +120,9 @@
 <http://identifiers.org/sgd/S000003319>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
@@ -125,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,14 +147,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_CHEBI_15688_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -158,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,30 +183,33 @@
           <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN0-2022_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15688_RXN3O-470>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-440" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -205,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -294,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -379,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -391,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,28 +424,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,37 +502,40 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/CHEBI_15688_RXN0-2022>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15688> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-440" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -541,7 +544,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -663,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,11 +761,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,25 +773,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://identifiers.org/sgd/S000004124>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004124>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -790,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,11 +819,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_CHEBI_15688_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,8 +831,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470>
+          <http://model.geneontology.org/CHEBI_15688_RXN3O-470>
 ] .
+
+<http://purl.obolibrary.org/obo/CHEBI_15688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -829,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate fermentation to acetoin III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -885,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,22 +949,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/CHEBI_15343_RXN-6161>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+] .
 
 <http://model.geneontology.org/RXN3O-470>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -960,7 +979,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN-6161> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470> ;
+                <http://model.geneontology.org/CHEBI_15688_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -968,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,31 +995,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
-] .
+<http://model.geneontology.org/CHEBI_15343_RXN-6161>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1025,7 +1042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,11 +1084,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_15688_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,7 +1096,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
+          <http://model.geneontology.org/CHEBI_15688_RXN0-2022>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1094,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1116,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,17 +1183,6 @@
           <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_cbed3a44-b8f4-4f48-9a77-f45d5e760c1a_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
@@ -1185,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1204,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,24 +1262,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37499> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1283,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,12 +1289,23 @@
           <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-118_RXN-6161_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1313,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1398,7 +1404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1420,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_15688_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1431,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1442,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,9 +1483,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
 ] .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0004737>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1482,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1490,22 +1504,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/5704112b-f068-497d-a863-309bb9563ce9_RXN3O-470>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1515,7 +1515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1544,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1560,7 +1560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1615,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1634,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1648,7 +1648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,23 +1659,23 @@
           <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15378_RXN-6161_SGD_PWY_YeastPathways_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-58_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1689,7 +1689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-45.ttl
+++ b/models/YeastPathways_PWY3O-45.ttl
@@ -1,9 +1,9 @@
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,6 +80,23 @@
           <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
 ] .
 
+<http://model.geneontology.org/3b0c40f9-b44c-4e2b-9d19-62a6c322939e_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://identifiers.org/sgd/S000004719>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -88,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,26 +168,26 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_17071>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17071>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002233_CHEBI_15377_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -356,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -540,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -648,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -722,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -851,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -892,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -937,11 +954,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -952,32 +988,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65402> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '6-(hydroxymethyl)-7,8-dihydropterin + ATP &rarr; (7,8-dihydropterin-6-yl)methyl diphosphate + AMP + H<SUP>+</SUP>' 'null' '4-aminobenzoate + (7,8-dihydropterin-6-yl)methyl diphosphate &rarr; 7,8-dihydropteroate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN>
-] .
 
 <http://purl.obolibrary.org/obo/GO_0046820>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -990,7 +1007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1093,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1110,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1123,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1176,7 +1193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1192,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1206,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,11 +1271,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1283,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
@@ -1274,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1292,28 +1309,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65429> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aminodeoxychorismate lyase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65794> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/H2PTERIDINEPYROPHOSPHOKIN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003848> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1334,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,12 +1344,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aminodeoxychorismate lyase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65794> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1441,7 +1458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1608,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1634,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1647,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1690,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1703,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1780,7 +1797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1806,11 +1823,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_3b0c40f9-b44c-4e2b-9d19-62a6c322939e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1818,7 +1835,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/3b0c40f9-b44c-4e2b-9d19-62a6c322939e_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
@@ -1828,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1853,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1864,29 +1881,12 @@
 <http://identifiers.org/sgd/S000005316>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1943,7 +1943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2046,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2062,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2083,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2096,18 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2122,13 +2111,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65552> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002333_YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2139,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2147,27 +2162,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2185,7 +2185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2204,7 +2204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2234,7 +2234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,7 +2253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2284,23 +2284,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2309,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2345,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2372,7 +2355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2388,7 +2371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,7 +2393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2421,23 +2404,12 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2449,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2465,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2479,7 +2451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,17 +2462,17 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
+<http://identifiers.org/sgd/S000004902>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000004902>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005200> ;
@@ -2509,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2522,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2533,7 +2505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2547,7 +2519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2566,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2582,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2596,7 +2568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2644,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2661,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2677,7 +2649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,7 +2668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2707,21 +2679,6 @@
           <http://model.geneontology.org/CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GTP-cyclohydrolase I" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65437> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2731,13 +2688,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65652> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GTP-cyclohydrolase I" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65437> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2747,7 +2719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2767,7 +2739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,11 +2751,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2791,7 +2763,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
@@ -2803,13 +2775,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65498> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2819,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2828,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2843,7 +2826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2859,7 +2842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2875,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2889,7 +2872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2908,7 +2891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2924,11 +2907,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_15740_GTP-CYCLOHYDRO-I-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
@@ -2939,28 +2937,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65417> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45Protein65535> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2970,7 +2953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2986,7 +2969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2997,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3015,7 +2998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3031,7 +3014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3050,7 +3033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3064,7 +3047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,7 +3080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3113,7 +3096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3132,7 +3115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3148,18 +3131,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57451> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_SGD_PWY_YeastPathways_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3184,7 +3184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3198,6 +3198,17 @@
 <http://purl.obolibrary.org/obo/GO_0003848>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" , "Provides Input For Rule. The relation '7,8-dihydroneopterin 3'-triphosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin 3'-phosphate + diphosphate + H<SUP>+</SUP>' 'null' '7,8-dihydroneopterin 3'-phosphate + H<sub>2</sub>O &rarr; 7,8-dihydroneopterin + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -3206,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3216,17 +3227,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_PWY_YeastPathways_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_44841>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3239,7 +3239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3255,7 +3255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3269,7 +3269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3283,6 +3283,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_3b0c40f9-b44c-4e2b-9d19-62a6c322939e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -3291,7 +3302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3316,7 +3327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3336,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3363,7 +3374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3385,7 +3396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3404,7 +3415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3423,7 +3434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3444,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3463,7 +3474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3474,7 +3485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3486,7 +3497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3505,7 +3516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3527,7 +3538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3546,7 +3557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3566,7 +3577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3579,7 +3590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3607,7 +3618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3622,15 +3633,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/3f2c7883-1401-46bb-8ee4-7d71fb0cb389_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/abebf4d2-e1d9-46a1-87cc-64d6088de975_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/3b0c40f9-b44c-4e2b-9d19-62a6c322939e_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3643,7 +3654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3657,7 +3668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3676,7 +3687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3695,7 +3706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3711,7 +3722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3725,7 +3736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3748,7 +3759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3761,7 +3772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3773,18 +3784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000066_reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-45>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3798,7 +3798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3814,7 +3814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3825,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-45" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-450.ttl
+++ b/models/YeastPathways_PWY3O-450.ttl
@@ -13,7 +13,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylcholine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,6 +543,17 @@
           <http://model.geneontology.org/RXN-5781>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_CHOLINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -552,24 +563,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450SmallMolecule21946> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_456216_CHOLINE-KINASE-RXN_SGD_PWY_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,12 +607,6 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_58779>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58779> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -622,13 +616,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450SmallMolecule21873> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58779>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,26 +650,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/YGR202C-MONOMER_2.7.7.15-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003434> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphorylcholine transferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450Protein21896> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_60377_RXN-5781_SGD_PWY_YeastPathways_PWY3O-450>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,20 +696,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YGR202C-MONOMER_2.7.7.15-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003434> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphorylcholine transferase" ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450Protein21896> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,12 +1040,14 @@
           <http://model.geneontology.org/CHEBI_58779_2.7.7.15-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-5781_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1054,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1085,14 +1087,12 @@
 <http://purl.obolibrary.org/obo/GO_0004105>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002413_2.7.7.15-RXN_SGD_PWY_YeastPathways_PWY3O-450>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+<http://model.geneontology.org/reaction_RXN-5781_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-450" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1101,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1220,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-48.ttl
+++ b/models/YeastPathways_PWY3O-48.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,6 +716,30 @@
           <http://model.geneontology.org/CHEBI_15378_1.1.1.8-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-48Protein50659> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
@@ -724,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,30 +758,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-48/YeastPathways_PWY3O-48>
 ] .
-
-<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-48Protein50659> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/reaction_GLYCEROL-1-PHOSPHATASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/1.1.1.8-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004367> ;
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_17754_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -802,17 +813,6 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002234_CHEBI_17754_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_PWY3O-48>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000864>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-48" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-5.ttl
+++ b/models/YeastPathways_PWY3O-5.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylulose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-50.ttl
+++ b/models/YeastPathways_PWY3O-50.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +94,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrapyrrole biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,6 +1220,15 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-50/YeastPathways_PWY3O-50>
 ] .
 
+<http://model.geneontology.org/reaction_UROGENIIISYN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1228,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,15 +1247,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_5-AMINOLEVULINIC-ACID-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/reaction_UROGENIIISYN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002364>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1392,7 +1392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1483,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-50" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-5268.ttl
+++ b/models/YeastPathways_PWY3O-5268.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "oleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,16 +324,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-5268SmallMolecule18110> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -343,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,12 +351,15 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_1.14.19.1-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_RXN-9666_RO_0002234_CHEBI_30823_RXN-9666_SGD_PWY_YeastPathways_PWY3O-5268>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -543,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-592.ttl
+++ b/models/YeastPathways_PWY3O-592.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin system - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,6 +984,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-592/YeastPathways_PWY3O-592>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-592" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-592/YeastPathways_PWY3O-592>
         a       <http://purl.obolibrary.org/obo/GO_0006749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -993,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1001,23 +1012,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002233_CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-592" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PRODISULFREDUCT-A-RXN_RO_0002413_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-592>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1064,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-592" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-5962.ttl
+++ b/models/YeastPathways_PWY3O-5962.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,7 +853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -898,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,7 +914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1220,7 +1220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,7 +1321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1385,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1394,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1698,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1712,7 +1712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1746,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1820,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1861,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1903,7 +1903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1968,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1982,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2001,7 +2001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2039,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2069,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2088,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2121,7 +2121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2132,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2171,7 +2171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2185,7 +2185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2204,7 +2204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2240,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2259,7 +2259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2286,7 +2286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2322,7 +2322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2352,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2396,7 +2396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,7 +2415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2442,7 +2442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2523,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2536,7 +2536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2547,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2558,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2571,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2588,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2601,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2626,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2642,7 +2642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2699,7 +2699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2718,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2748,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2761,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2775,7 +2775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2794,7 +2794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2813,7 +2813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2832,7 +2832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2868,7 +2868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2903,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2914,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2939,7 +2939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2952,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2974,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2992,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3023,7 +3023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3040,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3056,7 +3056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3070,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3079,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3093,7 +3093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,7 +3112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3131,7 +3131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3169,7 +3169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3185,7 +3185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3196,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3213,7 +3213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3231,7 +3231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3250,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,7 +3269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3289,7 +3289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3305,7 +3305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3321,7 +3321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3332,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3357,7 +3357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3374,7 +3374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated and unsaturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3387,7 +3387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3398,7 +3398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3423,7 +3423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3439,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3468,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3490,7 +3490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3504,7 +3504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3522,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3538,7 +3538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3554,7 +3554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3565,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3579,7 +3579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3601,7 +3601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3620,7 +3620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3640,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3656,7 +3656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3683,7 +3683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3696,7 +3696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3712,7 +3712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3731,7 +3731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3747,7 +3747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3761,7 +3761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,7 +3777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3788,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3803,7 +3803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3816,7 +3816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3825,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3836,7 +3836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3851,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3866,7 +3866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3882,7 +3882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3898,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3920,7 +3920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3929,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3940,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3953,7 +3953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3968,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3984,7 +3984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4000,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4014,7 +4014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4036,7 +4036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4055,7 +4055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4075,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4091,7 +4091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4110,7 +4110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4126,7 +4126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4140,7 +4140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4156,7 +4156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4170,7 +4170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4189,7 +4189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4200,7 +4200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4214,7 +4214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4230,7 +4230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4244,7 +4244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4264,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4281,7 +4281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4298,7 +4298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4311,7 +4311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4325,7 +4325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4336,7 +4336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4353,7 +4353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4367,7 +4367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4386,7 +4386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4405,7 +4405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4425,7 +4425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4438,7 +4438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4449,7 +4449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4463,7 +4463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4482,7 +4482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4501,7 +4501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4523,7 +4523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4539,7 +4539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4550,7 +4550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4564,7 +4564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4584,7 +4584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4597,7 +4597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4610,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4627,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4640,7 +4640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4651,7 +4651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4666,7 +4666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4682,7 +4682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4697,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4714,7 +4714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4727,7 +4727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4752,7 +4752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4768,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4783,7 +4783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4796,7 +4796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4807,7 +4807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4821,7 +4821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4840,7 +4840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4859,7 +4859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4875,7 +4875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4889,7 +4889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4911,7 +4911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4931,7 +4931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4947,7 +4947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4969,7 +4969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4988,7 +4988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5007,7 +5007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5022,7 +5022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5035,7 +5035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5050,7 +5050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5077,7 +5077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5090,7 +5090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5101,7 +5101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5110,7 +5110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5121,7 +5121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5135,7 +5135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5151,7 +5151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5168,7 +5168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5188,7 +5188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5201,7 +5201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5216,7 +5216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5232,7 +5232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5252,7 +5252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5269,7 +5269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5285,7 +5285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5304,7 +5304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5323,7 +5323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,7 +5345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5364,7 +5364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5380,7 +5380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5394,7 +5394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5410,7 +5410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5419,7 +5419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5434,7 +5434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5451,7 +5451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5464,7 +5464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5478,7 +5478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5494,7 +5494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5509,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5525,7 +5525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5544,7 +5544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5563,7 +5563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5593,7 +5593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5606,7 +5606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5620,7 +5620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5639,7 +5639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5655,7 +5655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5667,7 +5667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5686,7 +5686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5702,7 +5702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5713,7 +5713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5725,7 +5725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5744,7 +5744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5764,7 +5764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5780,7 +5780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5800,7 +5800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5817,7 +5817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5830,7 +5830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5844,7 +5844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5858,7 +5858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5877,7 +5877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5895,7 +5895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5912,7 +5912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5928,7 +5928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5944,7 +5944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5958,7 +5958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5974,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5987,7 +5987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6000,7 +6000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6014,7 +6014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6033,7 +6033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6049,7 +6049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6063,7 +6063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6083,7 +6083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6099,7 +6099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6115,7 +6115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6126,7 +6126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6140,7 +6140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6156,7 +6156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6171,7 +6171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6187,7 +6187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6207,7 +6207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6220,7 +6220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6243,7 +6243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6256,7 +6256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6273,7 +6273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6282,7 +6282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6297,7 +6297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6310,7 +6310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6324,7 +6324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6343,7 +6343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6359,7 +6359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6370,7 +6370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6385,7 +6385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6401,7 +6401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6417,7 +6417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6431,7 +6431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6447,7 +6447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6461,7 +6461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6483,7 +6483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6502,7 +6502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6518,7 +6518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6532,7 +6532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6562,7 +6562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6578,7 +6578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6594,7 +6594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6605,7 +6605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6620,7 +6620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6633,7 +6633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6644,7 +6644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6659,7 +6659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6677,7 +6677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6694,7 +6694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6707,7 +6707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6722,7 +6722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6735,7 +6735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6746,7 +6746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6760,7 +6760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6776,7 +6776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6790,7 +6790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6806,7 +6806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6820,7 +6820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6836,7 +6836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6850,7 +6850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6869,7 +6869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6885,7 +6885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6894,7 +6894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6908,7 +6908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6924,7 +6924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6938,7 +6938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6954,7 +6954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6963,7 +6963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6977,7 +6977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6996,7 +6996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7012,7 +7012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7027,7 +7027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7042,7 +7042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7055,7 +7055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7070,7 +7070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7083,7 +7083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7094,7 +7094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7105,7 +7105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7120,7 +7120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7137,7 +7137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7154,7 +7154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7167,7 +7167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7178,7 +7178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7189,7 +7189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7204,7 +7204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7219,7 +7219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7232,7 +7232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7243,7 +7243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7257,7 +7257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7276,7 +7276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7306,7 +7306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7322,7 +7322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7344,7 +7344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7360,7 +7360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7374,7 +7374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7394,7 +7394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7407,7 +7407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7421,7 +7421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7437,7 +7437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7449,7 +7449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7465,7 +7465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7479,7 +7479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7495,7 +7495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7509,7 +7509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7529,7 +7529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7542,7 +7542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7556,7 +7556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7565,7 +7565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7576,7 +7576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7588,7 +7588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7599,7 +7599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7610,7 +7610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7623,7 +7623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7632,7 +7632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7644,7 +7644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7660,7 +7660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7671,7 +7671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7688,7 +7688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7704,7 +7704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7715,7 +7715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7726,7 +7726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7740,7 +7740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7756,7 +7756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7773,7 +7773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7792,7 +7792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7812,7 +7812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7828,7 +7828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7847,7 +7847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7863,7 +7863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7874,7 +7874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7885,7 +7885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7897,7 +7897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7917,7 +7917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7933,7 +7933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7956,7 +7956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7972,7 +7972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7992,7 +7992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8009,7 +8009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8022,7 +8022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8033,7 +8033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8054,7 +8054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8070,7 +8070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8092,7 +8092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8104,7 +8104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8129,7 +8129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8142,7 +8142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8167,7 +8167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8183,7 +8183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8202,7 +8202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8224,7 +8224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8240,7 +8240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8254,7 +8254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8270,7 +8270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8284,7 +8284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8303,7 +8303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8322,7 +8322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8341,7 +8341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8360,7 +8360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8376,7 +8376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8387,7 +8387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8398,7 +8398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8409,7 +8409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8420,7 +8420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8431,7 +8431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8444,7 +8444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8457,7 +8457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8468,7 +8468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8479,7 +8479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8491,7 +8491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8510,7 +8510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8526,7 +8526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8540,7 +8540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8559,7 +8559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8578,7 +8578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8597,7 +8597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8616,7 +8616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8634,7 +8634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8650,7 +8650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8666,7 +8666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8677,7 +8677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8686,7 +8686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8697,7 +8697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8708,7 +8708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8721,7 +8721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8734,7 +8734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8749,7 +8749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8762,7 +8762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8773,7 +8773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8787,7 +8787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -8800,7 +8800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8820,7 +8820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8837,7 +8837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8854,7 +8854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8870,7 +8870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8889,7 +8889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8911,7 +8911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8930,7 +8930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8952,7 +8952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8972,7 +8972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8988,7 +8988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9007,7 +9007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9026,7 +9026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9045,7 +9045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9065,7 +9065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-6-1.ttl
+++ b/models/YeastPathways_PWY3O-6-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,7 +376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dehydro-D-arabinono-1,4-lactone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,6 +632,28 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6-1/YeastPathways_PWY3O-6-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9798>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13392> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -641,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,34 +671,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9797_RO_0002234_CHEBI_15378_RXN3O-9797_SGD_PWY_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002413_1.1.3.37-RXN_SGD_PWY_YeastPathways_PWY3O-6-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9798_RO_0002234_CHEBI_16292_RXN3O-9798_SGD_PWY_YeastPathways_PWY3O-6-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,7 +1017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,7 +1176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1243,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1265,7 +1265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-6336.ttl
+++ b/models/YeastPathways_PWY3O-6336.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,6 +226,15 @@
           <http://model.geneontology.org/RXN3O-5304>
 ] .
 
+<http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
@@ -234,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,21 +254,12 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9634>
 ] .
 
-<http://model.geneontology.org/reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,6 +331,17 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -339,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,17 +361,6 @@
           <http://model.geneontology.org/reaction_ENOYL-ACP-REDUCT-NADPH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9514_RO_0002333_YPL231W-MONOMER_RXN-9514_controller_SGD_PWY_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -813,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -882,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1175,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1449,7 +1449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,7 +1535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1669,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1686,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1749,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1763,7 +1763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1793,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1884,7 +1884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,7 +1903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1923,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1936,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,32 +1961,13 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9624_BFO_0000066_reaction_RXN-9624_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1997,12 +1978,31 @@
           <http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
+] .
+
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002234_CHEBI_15377_4.2.1.58-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2054,7 +2054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2073,7 +2073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2089,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2100,7 +2100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2166,7 +2166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2177,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2258,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2269,6 +2269,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2278,24 +2289,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68465> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000050_YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336_SGD_PWY_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2305,7 +2305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2321,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2335,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,7 +2354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2381,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2392,7 +2392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2422,7 +2422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2433,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2447,7 +2447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2484,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2499,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2515,7 +2515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2550,7 +2550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2563,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2579,7 +2579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2597,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2613,7 +2613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2640,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2657,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2703,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2718,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2731,18 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2753,7 +2742,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002413_RXN-9515_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2778,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2798,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2811,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2825,7 +2825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2866,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2882,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2896,7 +2896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2926,7 +2926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2945,7 +2945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2992,7 +2992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3011,7 +3011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3030,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3041,7 +3041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3055,7 +3055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,7 +3074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3093,7 +3093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,7 +3112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3132,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3147,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3164,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3207,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3220,7 +3220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3234,7 +3234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3261,7 +3261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3273,7 +3273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3293,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,7 +3309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3329,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3345,7 +3345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3363,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3379,7 +3379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3398,7 +3398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3414,7 +3414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3432,7 +3432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3449,7 +3449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3462,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3476,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3490,7 +3490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3506,7 +3506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3520,7 +3520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3540,7 +3540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3553,7 +3553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3568,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3584,7 +3584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,7 +3603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3614,17 +3614,6 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-6336/YeastPathways_PWY3O-6336>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57384_ACETYL-COA-CARBOXYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3634,13 +3623,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68524> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_RO_0002233_CHEBI_30616_ACETYL-COA-CARBOXYLTRANSFER-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3650,7 +3650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3680,7 +3680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3693,7 +3693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3725,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3741,7 +3741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3760,7 +3760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3780,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3793,7 +3793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3807,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3818,7 +3818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3829,7 +3829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3843,7 +3843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,7 +3862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3878,18 +3878,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3898,7 +3889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3923,7 +3914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3934,12 +3925,21 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9515>
 ] .
 
+<http://model.geneontology.org/reaction_RXN3O-5293_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3950,7 +3950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3962,7 +3962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3981,7 +3981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4001,7 +4001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4017,7 +4017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4036,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4052,7 +4052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4068,7 +4068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4088,7 +4088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4104,7 +4104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4120,7 +4120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4134,7 +4134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4150,7 +4150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4162,7 +4162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4182,7 +4182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4202,7 +4202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4219,7 +4219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4235,7 +4235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4256,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4269,7 +4269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4280,7 +4280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4294,7 +4294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4313,7 +4313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4331,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4344,7 +4344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4355,7 +4355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4369,7 +4369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4388,7 +4388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4404,7 +4404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4419,7 +4419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4446,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4459,7 +4459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4468,7 +4468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4482,7 +4482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4501,7 +4501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4517,7 +4517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4531,7 +4531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4550,7 +4550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4568,7 +4568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4584,7 +4584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4603,7 +4603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4619,7 +4619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4630,7 +4630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4645,7 +4645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4658,7 +4658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4672,7 +4672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4688,7 +4688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4703,7 +4703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4716,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4731,7 +4731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4750,7 +4750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4770,7 +4770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4787,7 +4787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4803,7 +4803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4822,7 +4822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4842,7 +4842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4855,7 +4855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4870,7 +4870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4887,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4900,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4914,7 +4914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4933,7 +4933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4952,7 +4952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4963,7 +4963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4974,7 +4974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4985,7 +4985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4996,7 +4996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5014,7 +5014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5030,7 +5030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5060,7 +5060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5073,7 +5073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5087,7 +5087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5098,7 +5098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5112,7 +5112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5131,7 +5131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5147,7 +5147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5159,7 +5159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5178,7 +5178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5197,7 +5197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5210,7 +5210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5226,7 +5226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5246,7 +5246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5262,7 +5262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5281,7 +5281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5300,7 +5300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5323,7 +5323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5336,7 +5336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5350,7 +5350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5376,7 +5376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5392,7 +5392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5412,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5425,7 +5425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5436,7 +5436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5450,7 +5450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5466,7 +5466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5480,7 +5480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5496,18 +5496,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5519,7 +5510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5535,7 +5526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5547,7 +5538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5558,12 +5549,21 @@
           <http://model.geneontology.org/CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_RXN-9624_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9624_RO_0002234_CHEBI_15378_RXN-9624_SGD_PWY_YeastPathways_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5574,7 +5574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5585,7 +5585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5599,7 +5599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5611,7 +5611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5627,7 +5627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5639,7 +5639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5658,7 +5658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5674,7 +5674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5689,7 +5689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5716,7 +5716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5732,7 +5732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5751,7 +5751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5771,7 +5771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5784,7 +5784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5795,7 +5795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5806,7 +5806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5820,7 +5820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5840,7 +5840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5855,7 +5855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5868,7 +5868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5885,7 +5885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5901,7 +5901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5915,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5926,7 +5926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5940,7 +5940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5956,7 +5956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5971,7 +5971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5984,7 +5984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6001,7 +6001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6021,7 +6021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6048,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6075,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6102,7 +6102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6115,7 +6115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6124,7 +6124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6139,7 +6139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6152,7 +6152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6163,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6174,7 +6174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6188,7 +6188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6204,7 +6204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6215,7 +6215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6229,7 +6229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6245,7 +6245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6263,7 +6263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6276,7 +6276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6290,7 +6290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6312,7 +6312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6332,7 +6332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6348,7 +6348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6367,7 +6367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6387,7 +6387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6400,7 +6400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6417,7 +6417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6433,7 +6433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6444,7 +6444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6455,7 +6455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6469,7 +6469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6488,7 +6488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6504,7 +6504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6518,7 +6518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6537,7 +6537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6557,7 +6557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6574,7 +6574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6589,7 +6589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6605,7 +6605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6621,7 +6621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6635,7 +6635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6649,7 +6649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6672,7 +6672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6688,7 +6688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6707,7 +6707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6725,7 +6725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6738,7 +6738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6752,7 +6752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6766,7 +6766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6785,7 +6785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6804,7 +6804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6823,7 +6823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6842,7 +6842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6858,7 +6858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6871,7 +6871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6884,7 +6884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6899,7 +6899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6915,7 +6915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6934,7 +6934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6953,7 +6953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6967,7 +6967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6986,7 +6986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7005,7 +7005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7023,7 +7023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7040,7 +7040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7055,7 +7055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7068,7 +7068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7085,7 +7085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7115,7 +7115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7131,7 +7131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7147,7 +7147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7158,7 +7158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7169,7 +7169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7184,7 +7184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7197,7 +7197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7208,7 +7208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -7220,7 +7220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7239,7 +7239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7259,7 +7259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7272,7 +7272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7283,7 +7283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7297,7 +7297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7313,7 +7313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7328,7 +7328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7343,7 +7343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7356,7 +7356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7381,7 +7381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7398,7 +7398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-64.ttl
+++ b/models/YeastPathways_PWY3O-64.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-64" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_SGD_S000006322_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-64>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -129,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,11 +269,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-64> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_SGD_S000006322_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-64> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +281,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-113_5.3.1.23-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
+          <http://model.geneontology.org/SGD_S000006322_CPLX3O-113_component>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_RO_0002234_CHEBI_58533_5-METHYLTHIOADENOSINE-PHOSPHORYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-64>
@@ -278,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,23 +466,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-113_5.3.1.23-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component_SGD_PWY_YeastPathways_PWY3O-64>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-64" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_R15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,21 +550,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_R15-RXN_RO_0002233_CHEBI_83813_R15-RXN_SGD_PWY_YeastPathways_PWY3O-64>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -669,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -739,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,13 +902,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-64Protein50934> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://identifiers.org/sgd/S000006322>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -927,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1038,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1126,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1142,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,6 +1185,9 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-64/YeastPathways_PWY3O-64>
 ] .
 
+<http://identifiers.org/sgd/S000003785>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15379_R147-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1200,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1233,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,9 +1244,6 @@
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
@@ -1258,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1319,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1347,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1488,7 +1482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1546,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1596,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1662,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1751,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1762,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,11 +1823,11 @@
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "methylthioribose-1 P isomerase" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-113_component> ;
+                <http://model.geneontology.org/SGD_S000006322_CPLX3O-113_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1849,7 +1843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1865,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1879,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1922,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1938,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1970,6 +1964,15 @@
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/SGD_S000006322_CPLX3O-113_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006322> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1992,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2005,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2019,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2083,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2122,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2135,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2146,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2157,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2199,7 +2202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2215,7 +2218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2226,7 +2229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2237,20 +2240,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-169_R145-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003785> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "methylthioribulose-1-phosphate dehydratase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2277,7 +2280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2293,7 +2296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2362,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2387,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-6407.ttl
+++ b/models/YeastPathways_PWY3O-6407.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis I (the dihydroxyacetone pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,20 +85,6 @@
           <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller>
 ] .
 
-<http://model.geneontology.org/02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
@@ -107,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,6 +103,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_29089_RXN-1623>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002413_RXN-1623_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -129,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -278,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,6 +289,9 @@
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_15835>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
@@ -300,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -342,9 +342,6 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/CHEBI_16975>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -356,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -368,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -397,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,37 +402,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0008654>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_YeastPathways_PWY3O-6407/YeastPathways_PWY3O-6407_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0008654>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -443,11 +440,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +452,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
+          <http://model.geneontology.org/CHEBI_15835_RXN3O-5279>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -469,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,23 +477,6 @@
           <http://model.geneontology.org/reaction_RXN3O-5279_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -504,11 +484,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +496,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
@@ -528,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -545,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -595,13 +575,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-6407" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -611,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -621,11 +612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,8 +624,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279>
+          <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
 ] .
+
+<http://model.geneontology.org/CHEBI_15835_RXN3O-5279>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15835> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -647,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,15 +699,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_15835_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9800> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,11 +722,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +734,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
+          <http://model.geneontology.org/CHEBI_15835_RXN3O-5279>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -737,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,15 +792,12 @@
           <http://model.geneontology.org/RXN-1623>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4105_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -967,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,17 +986,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000002210>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1004,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,23 +1012,12 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_43a9a4d8-3aed-4ee3-a21a-3ebb5450574b_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000066_reaction_RXN3O-9800_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6407>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1084,17 +1067,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" , "Provides Input For Rule. The relation 'glycerone phosphate + a long-chain acyl-CoA &rarr; 1-acyl-dihydroxyacetone-phosphate + coenzyme A' 'null' '1-acyl-dihydroxyacetone-phosphate + NADPH &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + NADP<sup>+</sup> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002413_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1109,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1112,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/02e84e76-3798-4dcd-99ea-2e1ea97077ea_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/CHEBI_15835_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1139,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,13 +1140,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407Protein20800> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
         a       <http://identifiers.org/sgd/S000002210> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1172,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1188,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,8 +1185,16 @@
           <http://model.geneontology.org/CHEBI_33184_RXN3O-5279>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002413_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279>
         a       <http://purl.obolibrary.org/obo/CHEBI_57642> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1211,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1228,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,7 +1238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-6499.ttl
+++ b/models/YeastPathways_PWY3O-6499.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,15 +195,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_1.1.1.8-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
@@ -212,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,6 +214,15 @@
           <http://model.geneontology.org/CHEBI_57597_1.1.1.8-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_1.1.1.8-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -376,7 +376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis II (the glycerol-3-phosphate pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -870,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1229,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1271,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-661.ttl
+++ b/models/YeastPathways_PWY3O-661.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-661" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-6635.ttl
+++ b/models/YeastPathways_PWY3O-6635.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,14 +172,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16975>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -193,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,11 +221,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +233,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279>
+          <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
@@ -247,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +285,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -317,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,12 +408,15 @@
           <http://model.geneontology.org/CHEBI_57642_1.1.1.8-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15835>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_16975_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,17 +447,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33184>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,17 +486,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" , "Provides Input For Rule. The relation 'glycerone phosphate + a long-chain acyl-CoA &rarr; 1-acyl-dihydroxyacetone-phosphate + coenzyme A' 'null' '1-acyl-dihydroxyacetone-phosphate + NADPH &rarr; a 1-acyl-<i>sn</i>-glycerol 3-phosphate + NADP<sup>+</sup> + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002413_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,15 +539,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_15835_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-9800> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +752,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/CHEBI_15835_RXN3O-5279> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,11 +777,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
+          <http://model.geneontology.org/CHEBI_15835_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/CHEBI_33184_GLYCEROL-3-P-ACYLTRANSFER-RXN>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -932,9 +932,6 @@
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/GO_0006654>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -962,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1001,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,14 +1014,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://identifiers.org/sgd/S000001386>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1037,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,23 +1141,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002411_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002333_YDL022W-MONOMER_1.1.1.8-RXN_controller_SGD_PWY_YeastPathways_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1194,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,7 +1196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,30 +1214,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635Protein37776> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/2b920b82-82ba-4ceb-bbb5-0837500b2cf5_RXN3O-5279>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004367>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1264,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1279,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1320,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1380,7 +1346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1412,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1442,7 +1408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,18 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1503,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1568,11 +1523,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_57287_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1535,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57287_RXN3O-5279>
+          <http://model.geneontology.org/CHEBI_15835_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002333_MONOMER3O-4095_RXN3O-5279_controller_SGD_PWY_YeastPathways_PWY3O-6635>
@@ -1588,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1602,7 +1557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1629,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1640,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1661,11 +1616,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_57783_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1628,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3eeae05a-eed9-41f3-b2d4-3228fcc53ee6_RXN3O-5279>
+          <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000066_reaction_RXN3O-5279_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-6635>
@@ -1681,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1728,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1785,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,6 +1751,9 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/YIL124W-MONOMER_RXN3O-9800_controller>
         a       <http://identifiers.org/sgd/S000001386> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1803,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,8 +1769,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/CHEBI_15835_RXN3O-5279>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15835> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -1823,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1850,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1866,7 +1838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1902,7 +1874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1918,7 +1890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1943,7 +1915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1958,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,6 +1957,17 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9800>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002413_RXN3O-9800_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1993,7 +1976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2020,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2031,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2075,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2091,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2102,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2110,3 +2093,14 @@
 
 <http://identifiers.org/sgd/S000005420>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_CHEBI_15835_RXN3O-5279_SGD_PWY_YeastPathways_PWY3O-6635>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWY3O-69.ttl
+++ b/models/YeastPathways_PWY3O-69.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -969,7 +969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,13 +1072,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://identifiers.org/sgd/S000000417> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ferrochelatase / precorrin-2 dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,11 +1197,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000000417>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57309_UROGENDECARBOX-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57309> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1212,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1228,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1267,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1278,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1325,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,7 +1548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1561,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1585,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1602,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1720,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,7 +1741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1751,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1760,7 +1763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1771,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1785,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1836,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1852,7 +1855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1871,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1883,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,13 +1981,13 @@
 ] .
 
 <http://model.geneontology.org/MONOMER3O-106_DIMETHUROPORDEHYDROG-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000417> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "ferrochelatase / precorrin-2 dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1997,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2025,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2066,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2077,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2091,7 +2094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2124,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2141,7 +2144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2150,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2165,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2185,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2198,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2228,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2239,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2252,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2268,7 +2271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2287,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2302,7 +2305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2335,7 +2338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2365,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2381,7 +2384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,7 +2403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2416,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2439,7 +2442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2459,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2489,7 +2492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2505,7 +2508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2555,7 +2558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,7 +2574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2600,7 +2603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2620,7 +2623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2644,7 +2647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2658,7 +2661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2677,7 +2680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,7 +2699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2712,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2726,7 +2729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2756,7 +2759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2802,7 +2805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2821,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2836,7 +2839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2852,7 +2855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2886,13 +2889,13 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/MONOMER3O-47_RXN-13403_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000001777> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "uroporphyrinogen-III C-methyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2911,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2933,7 +2936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2949,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2960,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2974,7 +2977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2989,7 +2992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3009,7 +3012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +3029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3043,7 +3046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3059,7 +3062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3075,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3086,21 +3089,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_UROGENIIISYN-RXN_RO_0002234_CHEBI_15377_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3114,7 +3114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3130,7 +3130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3141,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3152,7 +3152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3165,7 +3165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3195,7 +3195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3217,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3236,7 +3236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3255,7 +3255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,7 +3275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3291,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3302,7 +3302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3316,7 +3316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3338,7 +3338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3349,12 +3349,15 @@
           <http://model.geneontology.org/CHEBI_15378_DIMETHUROPORDEHYDROG-RXN>
 ] .
 
+<http://identifiers.org/sgd/S000001777>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-13403_RO_0002233_CHEBI_57308_UROGENIIISYN-RXN_SGD_PWY_YeastPathways_PWY3O-69>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3400,7 +3403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3419,7 +3422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3435,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3449,7 +3452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3465,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3476,7 +3479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3490,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3501,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3515,7 +3518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3534,7 +3537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3550,7 +3553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3561,7 +3564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3578,7 +3581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3600,7 +3603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3616,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3641,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3666,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3683,7 +3686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3699,7 +3702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3715,7 +3718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3730,7 +3733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3745,7 +3748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3761,7 +3764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3798,7 +3801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3814,7 +3817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3833,7 +3836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3853,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of heme and siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3866,7 +3869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3880,7 +3883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3896,7 +3899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +3910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3918,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3929,7 +3932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3940,7 +3943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3955,7 +3958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3977,7 +3980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,7 +4002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4018,7 +4021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4048,7 +4051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4061,7 +4064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4075,7 +4078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4097,7 +4100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4113,7 +4116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4127,7 +4130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4143,7 +4146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4154,7 +4157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4168,7 +4171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4191,7 +4194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4204,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-69" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-697.ttl
+++ b/models/YeastPathways_PWY3O-697.ttl
@@ -2,11 +2,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14,7 +14,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000003093>
@@ -27,11 +27,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_2339e3ca-1a8c-4373-8ad7-b420037cfbc7_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,22 +39,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/2339e3ca-1a8c-4373-8ad7-b420037cfbc7_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_57305>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57305>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,11 +97,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/2339e3ca-1a8c-4373-8ad7-b420037cfbc7_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -114,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,11 +176,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d3255285-428c-421c-809f-77f1f39a7f89_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,26 +188,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/d3255285-428c-421c-809f-77f1f39a7f89_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000000042>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -224,18 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -245,11 +229,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,15 +241,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
 ] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_2339e3ca-1a8c-4373-8ad7-b420037cfbc7_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -274,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -284,11 +282,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_39fd8be6-b40d-4baa-93c7-6dff191a5155_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +294,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/39fd8be6-b40d-4baa-93c7-6dff191a5155_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
@@ -307,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -317,11 +315,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +327,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004801>
@@ -343,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,17 +354,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NADP<sup>+</sup> &harr; a 5,10-methenyltetrahydrofolate + NADPH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -384,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -411,18 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -431,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -442,35 +429,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000001788_CPLX3O-317_component>
         a       <http://identifiers.org/sgd/S000001788> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -485,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -512,18 +482,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,13 +547,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66311> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_134413>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -575,13 +565,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697Protein66425> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/7a202b05-f587-48be-878e-654dcb28aad7_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -591,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -618,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -632,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +671,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_39fd8be6-b40d-4baa-93c7-6dff191a5155_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -673,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,12 +714,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_57451>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/fee89af5-523c-4a6f-b55b-b986b4d19389_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -711,11 +749,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +761,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
@@ -731,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,15 +800,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d3255285-428c-421c-809f-77f1f39a7f89_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_7a202b05-f587-48be-878e-654dcb28aad7_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +827,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/7a202b05-f587-48be-878e-654dcb28aad7_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
@@ -790,9 +839,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> , <http://model.geneontology.org/fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/d3255285-428c-421c-809f-77f1f39a7f89_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -800,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -885,11 +934,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_ed6a587f-5864-430c-b52e-c523cf816212_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +946,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/ed6a587f-5864-430c-b52e-c523cf816212_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -909,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,29 +1002,12 @@
           <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -984,27 +1016,21 @@
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,15 +1038,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1034,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,9 +1083,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/39fd8be6-b40d-4baa-93c7-6dff191a5155_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1067,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,17 +1129,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,25 +1189,31 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component>
+        a       <http://identifiers.org/sgd/S000000042> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1193,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1203,11 +1235,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,18 +1247,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,22 +1266,33 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_c01789f5-ef89-4f7b-b2d5-d0026b0278b3_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1261,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1274,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,11 +1329,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1298,7 +1341,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YGL125W-MONOMER_1.5.1.20-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
@@ -1306,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1327,11 +1370,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_c01789f5-ef89-4f7b-b2d5-d0026b0278b3_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,11 +1382,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN>
+          <http://model.geneontology.org/c01789f5-ef89-4f7b-b2d5-d0026b0278b3_1.5.1.20-RXN>
 ] .
-
-<http://model.geneontology.org/eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
@@ -1354,23 +1394,34 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/ed6a587f-5864-430c-b52e-c523cf816212_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697BiochemicalReaction66510> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1380,7 +1431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1426,11 +1477,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_27825224-5360-426a-ae7f-eb1504ef6147_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1489,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/27825224-5360-426a-ae7f-eb1504ef6147_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57540_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
@@ -1446,35 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_930713d3-1d92-44de-880b-f77ba9ba8f31_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1485,21 +1508,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/c01789f5-ef89-4f7b-b2d5-d0026b0278b3_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1507,7 +1547,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_15378_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
@@ -1515,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1524,26 +1564,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_63528>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1580,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1562,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,28 +1607,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -1610,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1621,22 +1633,25 @@
 <http://identifiers.org/sgd/S000002426>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1646,7 +1661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,43 +1677,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1706,8 +1702,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_27825224-5360-426a-ae7f-eb1504ef6147_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1717,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1742,29 +1749,29 @@
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000002426_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1779,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
 ] .
 
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
@@ -1782,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,23 +1816,12 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1833,55 +1829,43 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Provides Input For Rule. The relation 'glycine + a tetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methylenetetrahydrofolate + ammonium + CO<SUB>2</SUB> + NADH' 'null' 'a 5,10-methylenetetrahydrofolate + NAD<sup>+</sup> &rarr; a 5,10-methenyltetrahydrofolate + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1891,11 +1875,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,7 +1887,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
@@ -1913,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,17 +1907,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5-methyltetrahydrofolate + NAD<sup>+</sup> &larr; a 5,10-methylenetetrahydrofolate + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1949,32 +1933,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1949,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
@@ -1990,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2002,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2022,17 +1989,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/2339e3ca-1a8c-4373-8ad7-b420037cfbc7_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
-                <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/THYMIDYLATESYN-RXN> , <http://model.geneontology.org/1.5.1.15-RXN> , <http://model.geneontology.org/1.5.1.20-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/1.5.1.15-RXN> , <http://model.geneontology.org/1.5.1.20-RXN> , <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2045,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2060,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2072,11 +2039,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2084,7 +2051,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
@@ -2092,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2106,7 +2073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,7 +2111,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_7a202b05-f587-48be-878e-654dcb28aad7_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2158,18 +2136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2178,12 +2145,12 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2194,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2204,11 +2171,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2183,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
@@ -2224,7 +2191,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2234,11 +2223,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2235,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/48dbacae-14be-4fc1-a0c0-5fea9d98f939_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
@@ -2254,18 +2243,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YeastPathways_PWY3O-697/YeastPathways_PWY3O-697_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2326,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2360,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2372,11 +2364,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2384,7 +2376,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-697>
@@ -2392,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2419,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2435,7 +2427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2446,26 +2438,6 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_e2298fd4-7bcf-496e-a869-26e40e68468a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2474,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2487,9 +2459,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1b9e96a5-d34e-4d93-ab79-9fc9dd65183c_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/fee89af5-523c-4a6f-b55b-b986b4d19389_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2497,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2505,29 +2477,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/a8aadad0-1db2-4598-86e1-5ad1053dfd62_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000004801_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2535,30 +2515,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+          <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2568,7 +2526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2584,16 +2542,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/39fd8be6-b40d-4baa-93c7-6dff191a5155_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2606,7 +2581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2614,22 +2589,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_ed6a587f-5864-430c-b52e-c523cf816212_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2639,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2689,18 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2715,11 +2673,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66457> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ed6a587f-5864-430c-b52e-c523cf816212_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2731,7 +2709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2748,15 +2726,29 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/27825224-5360-426a-ae7f-eb1504ef6147_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000000042_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2764,8 +2756,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -2776,13 +2779,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66198> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2792,7 +2806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2811,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2822,7 +2836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2833,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2850,7 +2864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,19 +2875,36 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/d3255285-428c-421c-809f-77f1f39a7f89_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2884,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2914,7 +2945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2944,7 +2975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,7 +2998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2979,11 +3010,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2991,18 +3022,29 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_fee89af5-523c-4a6f-b55b-b986b4d19389_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_20502_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,26 +3052,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3040,7 +3071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3051,21 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3076,7 +3093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3087,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3099,7 +3116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3115,7 +3132,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3129,7 +3157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3147,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3163,7 +3191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3174,12 +3202,12 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3190,7 +3218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3204,7 +3232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3215,15 +3243,12 @@
           <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/1df332bd-3896-4c38-b9d2-3645b40f6cb9_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_15740_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3240,7 +3265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3256,7 +3281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3270,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,18 +3311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_463d8b31-eb18-4494-acdb-8343920932dc_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3312,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate interconversions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3328,7 +3342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3348,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3364,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3375,7 +3389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3386,7 +3400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3401,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3418,7 +3432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3438,17 +3452,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a4c32e6f-b251-4529-924d-2e1dd7a0fb7e_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/27825224-5360-426a-ae7f-eb1504ef6147_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_20502_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/1.5.1.15-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3464,7 +3478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3482,7 +3496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3498,7 +3512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3516,11 +3530,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3528,7 +3542,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
@@ -3540,9 +3554,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/b93b6eb0-a5ee-4a50-939e-7fde4a2b4f5e_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/7a202b05-f587-48be-878e-654dcb28aad7_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3550,7 +3564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3562,11 +3576,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_fee89af5-523c-4a6f-b55b-b986b4d19389_1.5.1.15-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3574,8 +3588,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0a86b3a-5069-4b58-b50c-fd6d18c2ebac_1.5.1.15-RXN>
+          <http://model.geneontology.org/fee89af5-523c-4a6f-b55b-b986b4d19389_1.5.1.15-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3585,7 +3602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3596,12 +3613,23 @@
           <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002413_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3615,7 +3643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3634,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3645,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3656,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3669,38 +3697,21 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7ebb1585-e640-47b2-8e83-dbfabffe2b10_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/c01789f5-ef89-4f7b-b2d5-d0026b0278b3_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697BiochemicalReaction66293> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/4be66b3f-175d-4ef4-91c1-a6c32d32d582_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3710,7 +3721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3743,7 +3754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3756,11 +3767,11 @@
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "glycine cleavage complex" ;
         <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
+                <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000000042_CPLX3O-213_component> , <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3772,11 +3783,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,7 +3795,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN>
+          <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
@@ -3795,7 +3806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3807,7 +3818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3825,7 +3836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3833,52 +3844,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_fd3decd4-5a0e-4a57-a365-8b5d94384dfd_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Provides Input For Rule. The relation 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' 'null' 'a tetrahydrofolate + NADP<sup>+</sup> &larr; a 7,8-dihydrofolate + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002413_DIHYDROFOLATEREDUCT-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/268c5702-6a78-4434-bb94-89ba90da193f_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3891,7 +3874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3902,23 +3885,6 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/c92a9bca-ffda-4719-b6ab-7db29cf76c30_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3928,7 +3894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3944,7 +3910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3955,12 +3921,23 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-697/YeastPathways_PWY3O-697>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3971,7 +3948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3981,11 +3958,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_20502_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3993,7 +3970,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
+          <http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
@@ -4005,7 +3982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4024,7 +4001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4035,9 +4012,6 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
-<http://model.geneontology.org/a4e2ee46-1013-45d3-aca0-77533ce3bf95_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -4046,7 +4020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4062,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -4072,11 +4046,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57945_1.5.1.20-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4084,7 +4058,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eea64a52-2b45-4f7a-bb83-5b51ebfa4589_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004329>
@@ -4092,17 +4066,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" , "Provides Input For Rule. The relation 'a 5,10-methenyltetrahydrofolate + H<sub>2</sub>O &harr; a 10-formyltetrahydrofolate + H<SUP>+</SUP>' 'null' 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002413_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -4118,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4138,7 +4112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4154,7 +4128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4174,24 +4148,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66265> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_fad9bd29-0a6e-4b78-9be5-109cb79efe46_FORMATETHFLIG-RXN_SGD_PWY_YeastPathways_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4201,7 +4164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4212,6 +4175,40 @@
           <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_134413_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_134413> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_20502_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_20502> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4221,7 +4218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4238,7 +4235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/YeastPathways_PWY3O-7.ttl
+++ b/models/YeastPathways_PWY3O-7.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,6 +674,9 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
@@ -682,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,15 +696,12 @@
           <http://model.geneontology.org/CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,6 +908,17 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
@@ -916,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,17 +938,6 @@
           <http://model.geneontology.org/CHEBI_13390_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_PWY3O-7/YeastPathways_PWY3O-7_SGD_PWY_YeastPathways_PWY3O-7>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,11 +979,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004017> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aspartate aminotransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39393> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_456216_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -994,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1002,27 +1017,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004017> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aspartate aminotransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39393> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002234_CHEBI_15378_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,7 +1075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,7 +1094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1200,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1220,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1296,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1318,7 +1318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1354,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,7 +1518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1551,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1602,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1613,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1643,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,6 +1698,21 @@
           <http://model.geneontology.org/CHEBI_16452_PYRUVATE-CARBOXYLASE-RXN>
 ] .
 
+<http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000422> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate carboxylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39337> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1707,28 +1722,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YBR218C-MONOMER_PYRUVATE-CARBOXYLASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000422> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate carboxylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39337> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1738,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,7 +1757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1794,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1847,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1863,7 +1863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1882,7 +1882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1898,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1918,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,7 +1961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1988,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2004,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2018,7 +2018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2043,8 +2043,16 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_43474>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2054,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,29 +2078,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_BFO_0000066_reaction_HOMOSERKIN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_43474>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000066_reaction_THRESYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-7>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2125,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2139,7 +2139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2172,7 +2172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,7 +2194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2252,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2268,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2282,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,7 +2301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2334,7 +2334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2364,7 +2364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2383,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2397,7 +2397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2416,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2435,7 +2435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2474,7 +2474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2493,7 +2493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2507,7 +2507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2526,7 +2526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2546,7 +2546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2559,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2576,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2590,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2601,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2614,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2630,7 +2630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2674,7 +2674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2718,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,7 +2734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2761,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2775,7 +2775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2794,7 +2794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2810,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2832,7 +2832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2843,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2858,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2874,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2904,7 +2904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2920,7 +2920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,17 +2931,6 @@
           <http://model.geneontology.org/CHEBI_57476_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_HOMOSERKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2951,13 +2940,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7SmallMolecule39277> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002234_CHEBI_29991_ASPAMINOTRANS-RXN_SGD_PWY_YeastPathways_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2967,7 +2967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2992,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-7" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-70.ttl
+++ b/models/YeastPathways_PWY3O-70.ttl
@@ -11,11 +11,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_30089_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_16261_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,19 +23,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CHITIN-DEACETYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_16261_CHITIN-DEACETYLASE-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -45,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +82,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -121,28 +110,8 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "chitosan" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -157,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -210,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitosan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -312,12 +281,15 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_16261>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -330,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,13 +348,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_16261_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> , <http://model.geneontology.org/YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -437,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -447,11 +419,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_30089_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +431,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CHITIN-DEACETYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5946d03c-e92b-45b3-8083-645ac6c82601_CHITIN-DEACETYLASE-RXN>
+          <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/YeastPathways_PWY3O-70/YeastPathways_PWY3O-70>
@@ -471,13 +443,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
                 "YeastPathways_PWY3O-70" ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
+
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_CHEBI_16261_CHITIN-DEACETYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-70>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_16261_CHITIN-DEACETYLASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16261> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "chitosan" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .

--- a/models/YeastPathways_PWY3O-743.ttl
+++ b/models/YeastPathways_PWY3O-743.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -389,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,18 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-743" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -655,7 +644,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,6 +875,17 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -884,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,23 +903,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002413_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -950,7 +950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,6 +1084,17 @@
           <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YeastPathways_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1093,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of guanine, xanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1101,23 +1112,12 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY_YeastPathways_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY_YeastPathways_PWY3O-743>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-8.ttl
+++ b/models/YeastPathways_PWY3O-8.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylose metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,18 +688,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN-8773_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -712,13 +703,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61268> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_RXN-8773_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_PWY3O-8514.ttl
+++ b/models/YeastPathways_PWY3O-8514.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,7 +796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1047,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1118,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1363,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1415,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1467,7 +1467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1483,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1568,7 +1568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1676,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1695,7 +1695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,7 +1711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1725,7 +1725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1815,7 +1815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1967,7 +1967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1986,7 +1986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2006,7 +2006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2022,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2053,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2069,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2157,7 +2157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2245,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-862.ttl
+++ b/models/YeastPathways_PWY3O-862.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ubiquinone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -819,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,23 +996,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1120_BFO_0000050_YeastPathways_PWY3O-862/YeastPathways_PWY3O-862_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1341,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1377,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1544,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1614,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1630,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1873,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1900,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1948,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1962,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,7 +2001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2045,7 +2045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2059,22 +2059,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_30763_RXN3O-1121>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30763> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4-hydroxybenzoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51672> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FPPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_84492_RXN-9003>
         a       <http://purl.obolibrary.org/obo/CHEBI_84492> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2085,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2098,48 +2100,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FPPSYN-RXN_RO_0002233_CHEBI_58057_GPPSYN-RXN_SGD_PWY_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FPPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
-] .
 
 <http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_30763_RXN3O-1121>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30763> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4-hydroxybenzoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51672> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2165,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2181,7 +2181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2200,7 +2200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2227,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2255,7 +2255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2292,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2309,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2326,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2342,7 +2342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2372,23 +2372,23 @@
           <http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002234_CHEBI_15377_RXN3O-75_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-75_BFO_0000066_reaction_RXN3O-75_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2399,7 +2399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,7 +2449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2465,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2476,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2490,7 +2490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2509,7 +2509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2525,7 +2525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2536,18 +2536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2560,13 +2549,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862Protein52077> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2576,7 +2576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2595,7 +2595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2611,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2622,7 +2622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2633,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2648,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2664,7 +2664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2680,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2703,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2719,7 +2719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2735,7 +2735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2752,7 +2752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2768,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2781,7 +2781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,7 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2805,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2816,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2833,7 +2833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2852,7 +2852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2873,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2903,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2917,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2926,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2938,7 +2938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2957,7 +2957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2973,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2984,7 +2984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2995,7 +2995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3006,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3017,7 +3017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3073,7 +3073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3092,7 +3092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3108,7 +3108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3131,7 +3131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3197,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3210,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3221,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3232,7 +3232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3249,7 +3249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3265,7 +3265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3279,7 +3279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3299,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3314,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,7 +3330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3349,7 +3349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3379,7 +3379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3395,7 +3395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3415,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3440,7 +3440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3456,7 +3456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3472,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3501,7 +3501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3515,7 +3515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3529,7 +3529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3545,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3559,7 +3559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3575,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3592,7 +3592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3611,7 +3611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3627,7 +3627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3644,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3658,7 +3658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3688,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3707,7 +3707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3723,7 +3723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3737,7 +3737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3756,7 +3756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3775,7 +3775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3798,7 +3798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3815,7 +3815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3831,7 +3831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3850,7 +3850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3866,7 +3866,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3880,7 +3891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3891,17 +3902,6 @@
           <http://model.geneontology.org/reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-54_BFO_0000066_reaction_RXN3O-54_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_RXN-8813>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3911,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3924,7 +3924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3938,7 +3938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3958,7 +3958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3974,7 +3974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4002,7 +4002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4018,7 +4018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4034,7 +4034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4049,7 +4049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4066,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4079,7 +4079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4090,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4104,7 +4104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4115,6 +4115,17 @@
           <http://model.geneontology.org/YeastPathways_PWY3O-862/YeastPathways_PWY3O-862>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
@@ -4123,7 +4134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4134,17 +4145,6 @@
           <http://model.geneontology.org/CHEBI_57907_RXN-8813>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YJL167W-MONOMER_GPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003703> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4152,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4165,7 +4165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4185,7 +4185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4201,7 +4201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4212,7 +4212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4235,7 +4235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4254,7 +4254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4270,7 +4270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4281,7 +4281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4292,7 +4292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4315,7 +4315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4328,7 +4328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4340,7 +4340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4360,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4376,7 +4376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4392,7 +4392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4403,7 +4403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4414,7 +4414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4429,7 +4429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4445,7 +4445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4464,7 +4464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4484,7 +4484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4504,7 +4504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4523,7 +4523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4542,7 +4542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4558,7 +4558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4569,7 +4569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4583,7 +4583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4602,7 +4602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4618,7 +4618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4629,7 +4629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4642,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4658,7 +4658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4677,7 +4677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4693,7 +4693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4708,7 +4708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4727,7 +4727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4743,7 +4743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4758,7 +4758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4771,18 +4771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4790,6 +4779,17 @@
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002234_CHEBI_1109_RXN3O-73_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4799,7 +4799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4818,7 +4818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4834,7 +4834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4843,7 +4843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4854,7 +4854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4865,7 +4865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4879,7 +4879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4898,7 +4898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4914,7 +4914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4928,7 +4928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4939,7 +4939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4954,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4970,7 +4970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4989,7 +4989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5005,7 +5005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5018,7 +5018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5045,7 +5045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5061,7 +5061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5075,7 +5075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5097,7 +5097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5111,7 +5111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5130,7 +5130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5148,7 +5148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5163,7 +5163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5179,7 +5179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5198,7 +5198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5220,7 +5220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5229,7 +5229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5243,7 +5243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5259,7 +5259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5273,7 +5273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5292,7 +5292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5308,7 +5308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5322,7 +5322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5341,7 +5341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5352,7 +5352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5363,7 +5363,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5377,7 +5388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5388,17 +5399,6 @@
           <http://model.geneontology.org/reaction_RXN3O-1120_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4-COUMARATE--COA-LIGASE-RXN_RO_0002233_CHEBI_12876_RXN3O-1118_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
@@ -5407,7 +5407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5423,7 +5423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5434,7 +5434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5448,7 +5448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5467,7 +5467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5483,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5497,7 +5497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5513,7 +5513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5527,7 +5527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5547,7 +5547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5560,7 +5560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5574,7 +5574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5590,7 +5590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5605,7 +5605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5621,7 +5621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5640,7 +5640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5660,7 +5660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5687,7 +5687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5700,7 +5700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5711,7 +5711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5732,7 +5732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5748,7 +5748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5767,7 +5767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5783,7 +5783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5801,7 +5801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5814,7 +5814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5828,7 +5828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5842,7 +5842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5858,7 +5858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5873,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5892,7 +5892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5908,7 +5908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5923,7 +5923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5936,7 +5936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5950,7 +5950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5970,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5986,7 +5986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5998,7 +5998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6014,7 +6014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6025,7 +6025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6036,7 +6036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6050,7 +6050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6064,7 +6064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6092,7 +6092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6111,7 +6111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6131,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6148,7 +6148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6168,7 +6168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6184,7 +6184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6203,7 +6203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6219,7 +6219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6234,7 +6234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6250,7 +6250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6264,7 +6264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6280,7 +6280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6295,7 +6295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6311,7 +6311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6330,7 +6330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6346,7 +6346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6361,7 +6361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6377,7 +6377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6396,7 +6396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6412,7 +6412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6426,7 +6426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6440,7 +6440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6459,7 +6459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6478,7 +6478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6489,7 +6489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6508,7 +6508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6524,7 +6524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6535,7 +6535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6548,7 +6548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6561,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6575,7 +6575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6594,7 +6594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6613,7 +6613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6627,7 +6627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6646,7 +6646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6666,7 +6666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6679,18 +6679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6701,7 +6690,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-73_RO_0002413_RXN3O-12_SGD_PWY_YeastPathways_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6714,7 +6714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6727,7 +6727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6741,7 +6741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6760,7 +6760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6780,7 +6780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6793,7 +6793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6804,7 +6804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -6817,7 +6817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6830,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6841,7 +6841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6852,7 +6852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6866,7 +6866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6886,7 +6886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6913,7 +6913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6926,7 +6926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6943,7 +6943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6954,31 +6954,12 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-102>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9805> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57907_RXN-8813>
-] .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002233_CHEBI_59789_2.1.1.114-RXN_SGD_PWY_YeastPathways_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6993,13 +6974,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51974> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN-8813_SGD_PWY_YeastPathways_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9805> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57907_RXN-8813>
+] .
 
 <http://model.geneontology.org/CHEBI_59789_RXN3O-54>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
@@ -7010,7 +7010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7027,7 +7027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7040,7 +7040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7066,7 +7066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7079,7 +7079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7093,7 +7093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7112,7 +7112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7131,7 +7131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7147,7 +7147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7162,7 +7162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7175,7 +7175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7190,7 +7190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7206,7 +7206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7225,7 +7225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7250,7 +7250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7266,7 +7266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7286,7 +7286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7302,7 +7302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7321,7 +7321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7340,7 +7340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7354,7 +7354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7370,7 +7370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-862" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-94.ttl
+++ b/models/YeastPathways_PWY3O-94.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of TCA cycle and glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,26 +280,26 @@
           <http://model.geneontology.org/CHEBI_16947_CITSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0044238>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_RO_0002233_CHEBI_30616_PYRUVATE-CARBOXYLASE-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0044238>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_PYRUVATE-CARBOXYLASE-RXN_BFO_0000050_YeastPathways_PWY3O-94/YeastPathways_PWY3O-94_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,18 +710,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -732,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,12 +731,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/SGD_S000002585_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002585> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YLR304C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -799,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -851,7 +851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1012,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1127,7 +1127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1194,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1206,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1476,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1509,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1602,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,7 +1636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1664,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1673,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1705,7 +1705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1766,7 +1766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1785,7 +1785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1843,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1855,7 +1855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,7 +1894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1908,7 +1908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1941,28 +1941,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63258> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1972,7 +1955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1991,7 +1974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2002,12 +1985,29 @@
           <http://model.geneontology.org/CHEBI_57287_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63258> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-44_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller_BFO_0000051_SGD_S000003581_CPLX3O-44_component_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2051,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2092,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2106,7 +2106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2131,7 +2131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2147,7 +2147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2162,7 +2162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2192,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2230,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2259,7 +2259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2290,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2304,7 +2304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2324,7 +2324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2337,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2358,7 +2358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2374,7 +2374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2393,7 +2393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2412,7 +2412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2446,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2462,7 +2462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2482,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2495,7 +2495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2509,7 +2509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2528,7 +2528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2544,7 +2544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2559,7 +2559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2575,7 +2575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2589,7 +2589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2605,7 +2605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2619,7 +2619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2639,7 +2639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2652,7 +2652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2667,7 +2667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,7 +2680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2691,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2705,7 +2705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,7 +2724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2763,7 +2763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2776,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2796,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2813,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2826,7 +2826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2837,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2865,7 +2865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2882,7 +2882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2902,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2919,7 +2919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2938,7 +2938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2957,7 +2957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2977,7 +2977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2993,7 +2993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3004,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3013,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3027,7 +3027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3043,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3054,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3065,7 +3065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3079,7 +3079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,7 +3097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3114,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3131,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3147,7 +3147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3163,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3177,7 +3177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3193,7 +3193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3204,7 +3204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3216,7 +3216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3232,7 +3232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3247,7 +3247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,7 +3260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3271,7 +3271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3285,7 +3285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3307,7 +3307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3337,7 +3337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3360,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3376,7 +3376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3390,7 +3390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3406,7 +3406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3420,7 +3420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3436,7 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3459,7 +3459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3472,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3486,7 +3486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3506,7 +3506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3519,7 +3519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3533,7 +3533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3549,7 +3549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3562,7 +3562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3600,7 +3600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3616,7 +3616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3627,7 +3627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3642,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3655,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3667,7 +3667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3697,7 +3697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3710,7 +3710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3727,7 +3727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3746,7 +3746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3762,7 +3762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3773,7 +3773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3784,7 +3784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3798,7 +3798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3817,7 +3817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3826,25 +3826,6 @@
           <http://model.geneontology.org/ACONITATEDEHYDR-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/MALATE-DEH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
@@ -3856,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3864,12 +3845,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY_YeastPathways_PWY3O-94> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/MALATE-DEH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_15378_MALATE-DEH-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3894,7 +3894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3910,7 +3910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3929,7 +3929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3948,7 +3948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3968,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3981,7 +3981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3992,7 +3992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4005,7 +4005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4021,7 +4021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4038,7 +4038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4054,7 +4054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4065,7 +4065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4076,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4090,7 +4090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4106,7 +4106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4117,7 +4117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4131,7 +4131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4150,7 +4150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4169,7 +4169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4178,7 +4178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4192,7 +4192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4206,7 +4206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4225,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4239,7 +4239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4258,7 +4258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4277,7 +4277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4293,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4323,7 +4323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4336,7 +4336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4347,7 +4347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4361,7 +4361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4377,7 +4377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4391,7 +4391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4407,7 +4407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4418,7 +4418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4432,7 +4432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4452,7 +4452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4465,7 +4465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4476,7 +4476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4487,7 +4487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4501,7 +4501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4517,7 +4517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4532,7 +4532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,7 +4548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4567,7 +4567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4587,7 +4587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4604,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4620,7 +4620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4639,7 +4639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4655,7 +4655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4668,7 +4668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4681,7 +4681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4692,7 +4692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4703,7 +4703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4716,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4732,7 +4732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4751,7 +4751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4764,7 +4764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4780,7 +4780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4796,7 +4796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4813,7 +4813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4824,7 +4824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4838,7 +4838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4857,7 +4857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4875,7 +4875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4891,7 +4891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4900,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4911,7 +4911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4922,7 +4922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4936,7 +4936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4960,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4973,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4998,7 +4998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5014,7 +5014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5034,7 +5034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5051,7 +5051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5067,7 +5067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5079,7 +5079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5095,7 +5095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5109,7 +5109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5123,7 +5123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5143,7 +5143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5154,15 +5154,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
@@ -5171,7 +5162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5182,12 +5173,21 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002234_CHEBI_15378_MALSYN-RXN_SGD_PWY_YeastPathways_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5201,7 +5201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5220,7 +5220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5241,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5263,7 +5263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5279,7 +5279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5297,7 +5297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5313,7 +5313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5332,7 +5332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5351,7 +5351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5367,7 +5367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5378,7 +5378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5392,7 +5392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5411,7 +5411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5422,7 +5422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5433,7 +5433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5444,7 +5444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5456,7 +5456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5472,7 +5472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5483,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5500,7 +5500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5517,7 +5517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5536,7 +5536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5553,7 +5553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5572,7 +5572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5588,7 +5588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5602,7 +5602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5621,7 +5621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5641,7 +5641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5654,7 +5654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5665,7 +5665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5680,7 +5680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5696,7 +5696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5715,7 +5715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5729,7 +5729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5745,7 +5745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5756,7 +5756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5767,7 +5767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5778,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5795,7 +5795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5814,7 +5814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5833,7 +5833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5849,7 +5849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5860,7 +5860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5874,7 +5874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5897,7 +5897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5913,7 +5913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5929,7 +5929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5941,7 +5941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5957,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5968,7 +5968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5979,7 +5979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5993,7 +5993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6009,7 +6009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -6020,7 +6020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -6031,7 +6031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-94" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PWY3O-954.ttl
+++ b/models/YeastPathways_PWY3O-954.ttl
@@ -1,3 +1,14 @@
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_544567d5-e788-445e-9138-88f1977fe4e0_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
@@ -6,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -34,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,12 +254,29 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/c502e215-97a0-44cb-8ca2-9cd7cab6acf8_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002233_CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,12 +425,23 @@
           <http://model.geneontology.org/reaction_ACETYLHOMOSER-CYS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_537519_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -417,24 +456,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64238> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -445,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,24 +551,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64095> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -550,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -635,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -727,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -824,9 +841,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/544567d5-e788-445e-9138-88f1977fe4e0_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22> ;
+                <http://model.geneontology.org/c502e215-97a0-44cb-8ca2-9cd7cab6acf8_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -834,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -887,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -909,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -989,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,6 +1050,17 @@
           <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_c502e215-97a0-44cb-8ca2-9cd7cab6acf8_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1041,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,7 +1119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1185,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1204,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1272,11 +1300,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_544567d5-e788-445e-9138-88f1977fe4e0_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1312,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22>
+          <http://model.geneontology.org/544567d5-e788-445e-9138-88f1977fe4e0_RXN3O-22>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004414>
@@ -1298,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1343,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,17 +1418,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YeastPathways_PWY3O-954>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1410,13 +1427,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YLR303W-MONOMER_ACETYLHOMOSER-CYS-RXN_controller>
         a       <http://identifiers.org/sgd/S000004294> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1425,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1442,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1489,7 +1517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1543,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1580,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,7 +1639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1691,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1719,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1732,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1749,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1770,11 +1798,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_c502e215-97a0-44cb-8ca2-9cd7cab6acf8_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1782,7 +1810,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22>
+          <http://model.geneontology.org/c502e215-97a0-44cb-8ca2-9cd7cab6acf8_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
@@ -1794,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1832,7 +1860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1859,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1902,7 +1930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1916,7 +1944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1962,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1976,7 +2004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2001,7 +2029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2039,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2053,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,7 +2097,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2077,17 +2116,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_57844_HOMOCYSMET-RXN_SGD_PWY_YeastPathways_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004073> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2108,7 +2136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2121,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2133,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2158,7 +2186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2180,7 +2208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2226,7 +2254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,18 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-954" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2262,7 +2279,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57716_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2284,7 +2312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2301,7 +2329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2317,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2331,7 +2359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2353,7 +2381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,6 +2392,23 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
+<http://model.geneontology.org/544567d5-e788-445e-9138-88f1977fe4e0_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2373,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2389,7 +2434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2411,7 +2456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2447,7 +2492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2470,28 +2515,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule64147> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/522f1a83-5d01-4769-abf9-df706214bba1_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2500,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2517,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2526,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2554,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2567,7 +2595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2583,7 +2611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,7 +2630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2613,17 +2641,6 @@
           <http://model.geneontology.org/CHEBI_456216_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
@@ -2632,7 +2649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2668,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2682,7 +2699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2701,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2731,7 +2748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,29 +2759,12 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/5360fbde-5ab3-4e5c-9568-d8c4a203e3f4_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_CHEBI_29985_RXN3O-22_SGD_PWY_YeastPathways_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2775,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2786,30 +2786,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
-] .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -2830,13 +2811,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954BiochemicalReaction64018> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY_YeastPathways_PWY3O-954> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
+] .
 
 <http://identifiers.org/sgd/S000005767>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2849,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2868,7 +2868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2898,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2911,7 +2911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-96.ttl
+++ b/models/YeastPathways_PWY3O-96.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinamide riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -708,7 +708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -845,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PWY3O-981.ttl
+++ b/models/YeastPathways_PWY3O-981.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,11 +40,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,11 +338,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022>
+          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
 ] .
 
 <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -370,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -409,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,14 +453,8 @@
           <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://identifiers.org/sgd/S000004714>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16526_RXN-6081>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -471,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,15 +473,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://identifiers.org/sgd/S000004714>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -514,11 +514,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_CHEBI_15688_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470>
+          <http://model.geneontology.org/CHEBI_15688_RXN3O-470>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -537,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -594,7 +594,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_15688_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -605,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,17 +698,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-6081>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -713,7 +713,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_16583_RXN-6081> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15688_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-79_ACETOINDEHYDROG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,29 +729,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15378_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -775,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,6 +803,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17499_RXN-6081>
 ] .
+
+<http://model.geneontology.org/CHEBI_15688_RXN0-2022>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15688> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004737>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -832,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -892,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1064,7 +1064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,15 +1155,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_15688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_58476_ACETOLACTSYN-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,23 +1202,12 @@
           <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002333_CPLX3O-118_RXN3O-470_controller_SGD_PWY_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002413_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,6 +1289,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
+
+<http://model.geneontology.org/CHEBI_15688_RXN3O-470>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15688> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000056>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1305,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1365,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1380,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,35 +1492,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-118_RXN0-2022_controller_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1511,11 +1514,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_15688_ACETOINDEHYDROG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15688> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -1526,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1542,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1551,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,7 +1631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1685,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1705,7 +1725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,20 +1736,20 @@
           <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
 ] .
 
-<http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1740,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1778,7 +1798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1794,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1820,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1844,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1858,7 +1878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1874,7 +1894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1896,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1953,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,7 +1989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2049,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2060,23 +2080,6 @@
 <http://purl.obolibrary.org/obo/GO_0003984>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0000721>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2085,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2096,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2138,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN-6161> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470> ;
+                <http://model.geneontology.org/CHEBI_15688_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2143,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2159,7 +2162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2225,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2239,7 +2242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2258,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2274,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2288,7 +2291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,11 +2306,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_57540_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_15688_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2318,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/CHEBI_15688_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/contributor>
@@ -2326,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2337,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,7 +2376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2384,21 +2387,12 @@
           <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
 
-<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2412,7 +2406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2423,6 +2417,15 @@
           <http://model.geneontology.org/CHEBI_15686_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
@@ -2431,7 +2434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2478,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2489,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2499,11 +2502,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_15688_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2514,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16526_RXN0-2022>
+          <http://model.geneontology.org/CHEBI_15688_RXN0-2022>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2522,7 +2525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,7 +2544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2552,23 +2555,12 @@
           <http://model.geneontology.org/SGD_S000000515_CPLX3O-30_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_6627bdf9-21a2-4b0a-a082-455d0290ebc7_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2582,7 +2574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,7 +2594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2619,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2636,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of acetoin and butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2666,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2682,7 +2674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2698,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2715,7 +2707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,7 +2726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2761,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2775,7 +2767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2795,24 +2787,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64624> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_e5e16a70-d20c-4c12-a478-60e063b22c74_ACETOINDEHYDROG-RXN_SGD_PWY_YeastPathways_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-67_RXN-6161_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -2823,7 +2804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2840,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2853,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2868,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2890,7 +2871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,7 +2891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2962,7 +2943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2971,12 +2952,21 @@
 <http://identifiers.org/sgd/S000000515>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_BFO_0000066_reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2987,18 +2977,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN3O-470_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3010,7 +2991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3021,6 +3002,17 @@
           <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_CHEBI_15688_RXN3O-470_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3030,7 +3022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3046,7 +3038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3062,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3076,7 +3068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3096,7 +3088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3112,7 +3104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3132,7 +3124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3148,7 +3140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3167,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3186,7 +3178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3200,7 +3192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3219,7 +3211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3233,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/33b665e5-606c-492a-a994-beb81fb17f9c_RXN0-2022> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/CHEBI_15688_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3249,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3262,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3273,7 +3265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3288,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3301,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3314,7 +3306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,7 +3322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3346,7 +3338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3360,7 +3352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3396,7 +3388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3412,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3426,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3437,7 +3429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3451,7 +3443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,3 +3453,14 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PWY3O-981/YeastPathways_PWY3O-981>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_15688_RXN0-2022_SGD_PWY_YeastPathways_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_PWYQT-4432.ttl
+++ b/models/YeastPathways_PWYQT-4432.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -100,23 +100,6 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN-6601>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -129,7 +112,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
+                <http://model.geneontology.org/379cb3a1-3607-4b71-a028-33c683150816_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -137,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -166,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -182,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -213,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -305,18 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -328,6 +300,17 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_379cb3a1-3607-4b71-a028-33c683150816_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'glutathione + a proteinogenic amino acid &rarr; an &alpha;-(&gamma;-L-glutamyl)-L-amino acid + L-cysteinylglycine' 'null' 'L-cysteinylglycine + H<sub>2</sub>O &rarr; L-cysteine + glycine' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
@@ -336,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -576,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,11 +574,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_379cb3a1-3607-4b71-a028-33c683150816_RXN-6601_SGD_PWY_YeastPathways_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +586,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b71a5da3-d7b2-47d2-8226-bbf89bdb517b_RXN-6601>
+          <http://model.geneontology.org/379cb3a1-3607-4b71-a028-33c683150816_RXN-6601>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -623,7 +606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -722,11 +705,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62617> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/379cb3a1-3607-4b71-a028-33c683150816_RXN-6601>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_PYRIMID-RNTSYN-PWY.ttl
+++ b/models/YeastPathways_PYRIMID-RNTSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,6 +80,17 @@
           <http://model.geneontology.org/CHEBI_43474_ASPCARBTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004152> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -87,9 +98,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000050>
                 <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN> ;
+                <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN> , <http://model.geneontology.org/CHEBI_36141_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_17594_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -97,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,23 +116,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002333_YMR271C-MONOMER_OROPRIBTRANS-RXN_controller_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -356,19 +356,33 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
+<http://model.geneontology.org/CHEBI_36141_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_36141> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_32814>
@@ -382,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,12 +574,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,23 +602,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_RO_0002234_CHEBI_46398_UDPKIN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_CTPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002234_CHEBI_456216_CARBPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -624,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,11 +686,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +698,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-12002_BFO_0000066_reaction_RXN-12002_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
@@ -692,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -762,18 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -825,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -885,7 +888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,15 +902,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_CTPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -917,13 +911,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46302> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_OROPRIBTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -934,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +950,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_17594_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -962,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -993,7 +1007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1103,12 +1117,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_36141>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002234_CHEBI_29888_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1344,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1408,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,12 +1470,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,12 +1496,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ASPCARBTRANS-RXN_BFO_0000066_reaction_ASPCARBTRANS-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_OROPRIBTRANS-RXN_RO_0002413_OROTPDECARB-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,7 +1535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1544,11 +1561,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36141_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1573,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_36141_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004590>
@@ -1570,7 +1587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1658,7 +1675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1674,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1689,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1705,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1808,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1858,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1874,7 +1891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,7 +1913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1918,7 +1935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1949,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1965,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2027,7 +2044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2049,7 +2066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2079,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2128,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2137,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2148,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2173,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2206,7 +2223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2272,7 +2289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,12 +2300,23 @@
           <http://model.geneontology.org/CHEBI_43474_CARBPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2313,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2326,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2337,22 +2365,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_BFO_0000066_reaction_DIHYDROOROT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_17594_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_17594> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2366,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2383,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2396,7 +2430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2428,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2445,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2461,7 +2495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2491,7 +2525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2517,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2536,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2552,7 +2586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2567,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2580,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2591,7 +2625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2606,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2622,7 +2656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2672,7 +2706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,7 +2726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2708,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2728,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2744,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2762,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2806,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2820,7 +2854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,7 +2876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2862,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2881,7 +2915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2900,7 +2934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2919,7 +2953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2929,6 +2963,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY>
 ] .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36141_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/DIHYDROOROT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004151> ;
@@ -2949,7 +2994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2968,7 +3013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,11 +3028,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_17594_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2995,7 +3040,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/CHEBI_17594_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3006,7 +3051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,7 +3067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3052,7 +3097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3067,7 +3112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3083,7 +3128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3092,7 +3137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3107,7 +3152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3123,7 +3168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3139,7 +3184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3156,7 +3201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3178,7 +3223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3216,7 +3261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3239,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3261,7 +3306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3276,7 +3321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3289,7 +3334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3298,7 +3343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3312,7 +3357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3331,7 +3376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3353,7 +3398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,7 +3416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3384,7 +3429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3409,7 +3454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3439,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3452,7 +3497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3463,7 +3508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3474,11 +3519,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17594>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30864_DIHYDROOROT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3489,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3505,7 +3553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3533,7 +3581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3552,7 +3600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3571,7 +3619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3594,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3609,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3622,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3634,7 +3682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3645,23 +3693,6 @@
           <http://model.geneontology.org/CHEBI_58223_RXN-12002>
 ] .
 
-<http://model.geneontology.org/d4a6f66a-9881-4c57-a002-75ed8a866537_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
@@ -3670,7 +3701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3686,35 +3717,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3728,7 +3742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3739,17 +3753,6 @@
           <http://model.geneontology.org/reaction_DIHYDROOROT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROOROT-RXN_RO_0002413_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
@@ -3758,7 +3761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,7 +3777,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3785,7 +3799,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3796,29 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CTPSYN-RXN_BFO_0000050_YeastPathways_PYRIMID-RNTSYN-PWY/YeastPathways_PYRIMID-RNTSYN-PWY_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_9f4b4e09-6a17-4222-8b72-48e2a538d7bd_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3831,7 +3834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3848,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3861,7 +3864,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3872,18 +3886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OROTPDECARB-RXN_RO_0002233_CHEBI_57538_OROPRIBTRANS-RXN_SGD_PWY_YeastPathways_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3892,7 +3895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3906,7 +3909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_PYRUVDEHYD-PWY.ttl
+++ b/models/YeastPathways_PYRUVDEHYD-PWY.ttl
@@ -1,37 +1,9 @@
-<http://model.geneontology.org/e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57288_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -53,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,11 +52,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_80219_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +64,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133>
+          <http://model.geneontology.org/CHEBI_80219_RXN0-1133>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -103,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,18 +138,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_80218_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +154,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132>
+          <http://model.geneontology.org/CHEBI_80218_RXN0-1132>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN0-1132>
@@ -197,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,22 +174,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/CHEBI_80219_RXN0-1133>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_80219> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/GO_0006086> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -231,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -239,8 +214,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/CHEBI_80218_RXN0-1132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_80218> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_80219_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,11 +265,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_80219_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,36 +277,36 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133>
+          <http://model.geneontology.org/CHEBI_80219_RXN0-1133>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+          "Provides Input For Rule. The relation 'pyruvate + a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + H<SUP>+</SUP> &rarr; a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine + CO<SUB>2</SUB>' 'null' 'acetyl-CoA + a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine &larr; a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine + coenzyme A' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002411_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002413_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN0-1133>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_80219>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -320,17 +320,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1134_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_80218_RXN0-1132> , <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_RXN0-1134> , <http://model.geneontology.org/cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_80404_RXN0-1134> , <http://model.geneontology.org/CHEBI_16526_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER178W-MONOMER_RXN0-1134_controller> , <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN0-1133> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_80218_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -466,24 +477,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43786> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_bbd189c0-1da8-4729-985f-93485543d892_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -492,11 +492,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_CHEBI_80404_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134>
+          <http://model.geneontology.org/CHEBI_80404_RXN0-1134>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,27 +548,10 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/GO_0004148>
+<http://purl.obolibrary.org/obo/CHEBI_80218>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/ECO_0000363>
+<http://purl.obolibrary.org/obo/GO_0004148>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000050_YeastPathways_PYRUVDEHYD-PWY/YeastPathways_PYRUVDEHYD-PWY_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
@@ -576,40 +559,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002411_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/ECO_0000363>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -624,23 +588,34 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1133_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134> , <http://model.geneontology.org/CHEBI_57287_RXN0-1133> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN0-1133> , <http://model.geneontology.org/CHEBI_80404_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57288_RXN0-1133> , <http://model.geneontology.org/d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133> ;
+                <http://model.geneontology.org/CHEBI_80219_RXN0-1133> , <http://model.geneontology.org/CHEBI_57288_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN0-1132> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYBiochemicalReaction43825> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002333_YFL018C-MONOMER_RXN0-1132_controller_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -650,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,8 +636,22 @@
           <http://model.geneontology.org/CHEBI_15361_RXN0-1134>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_80404>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0004739>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_80404_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57288>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -676,6 +665,23 @@
 <http://purl.obolibrary.org/obo/GO_0030523>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_80404_RXN0-1134>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_80404> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
@@ -684,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,37 +720,6 @@
           <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://identifiers.org/sgd/S000000980>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "pyruvate decarboxylation to acetyl CoA - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
@@ -753,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,11 +739,25 @@
           <http://model.geneontology.org/CHEBI_57287_RXN0-1133>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57945>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "pyruvate decarboxylation to acetyl CoA - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/b7250010-b5e9-44e0-ad44-50a874f211af_RXN0-1134>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://identifiers.org/sgd/S000000980>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -778,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,16 +793,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57945>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -823,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,23 +815,12 @@
           <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002411_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -862,9 +832,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://model.geneontology.org/RXN0-1132>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004148> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -874,9 +841,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_RXN0-1132> , <http://model.geneontology.org/80c5882a-fd0a-4f46-a1b9-900130fbbc87_RXN0-1133> ;
+                <http://model.geneontology.org/CHEBI_80219_RXN0-1133> , <http://model.geneontology.org/CHEBI_57540_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> , <http://model.geneontology.org/e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132> ;
+                <http://model.geneontology.org/CHEBI_80218_RXN0-1132> , <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -884,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,6 +865,17 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_80219_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -906,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -917,17 +895,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+          "Provides Input For Rule. The relation 'acetyl-CoA + a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine &larr; a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine + coenzyme A' 'null' 'a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine + NAD<sup>+</sup> &rarr; a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine + NADH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002411_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002413_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -943,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -955,11 +933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_80218_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +945,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132>
+          <http://model.geneontology.org/CHEBI_80218_RXN0-1132>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -980,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,11 +1014,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_80404_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1026,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cf0b1f01-ae6a-4665-a00d-27c180a017e6_RXN0-1134>
+          <http://model.geneontology.org/CHEBI_80404_RXN0-1134>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1063,28 +1041,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/d8f5b426-25ab-470b-b880-5c75bd7df0cd_RXN0-1133>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1093,7 +1054,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002413_RXN0-1133_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1125,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1145,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1184,7 +1156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,17 +1167,6 @@
           <http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_e4d4b3ce-059c-43d5-af0b-73be83de0bb5_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
@@ -1214,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1239,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1273,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1253,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002413_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1306,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,3 +1288,25 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_RXN0-1134>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_CHEBI_80404_RXN0-1134_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_80218_RXN0-1132_SGD_PWY_YeastPathways_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SAM-PWY.ttl
+++ b/models/YeastPathways_SAM-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -265,6 +265,17 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_SAM-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SAM-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
@@ -273,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,17 +294,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_59789_S-ADENMETSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002333_YLR180W-MONOMER_S-ADENMETSYN-RXN_controller_SGD_PWY_YeastPathways_SAM-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SAM-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002910>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "S-adenosyl-L-methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SAM-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_SERDEG-PWY.ttl
+++ b/models/YeastPathways_SERDEG-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_SERSYN-PWY.ttl
+++ b/models/YeastPathways_SERSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,17 +709,6 @@
           <http://model.geneontology.org/YGR208W-MONOMER_RXN0-5114_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_18110_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,13 +782,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SERSYN-PWYSmallMolecule50375> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/PGLYCDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004617> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -809,24 +820,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SERSYN-PWYBiochemicalReaction50362> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_57945_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -836,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,6 +910,17 @@
           <http://model.geneontology.org/CHEBI_43474_RXN0-5114>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57945_PGLYCDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -919,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,18 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002233_CHEBI_57540_PGLYCDEHYDROG-RXN_SGD_PWY_YeastPathways_SERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,6 +1246,6 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .

--- a/models/YeastPathways_SO4ASSIM-PWY.ttl
+++ b/models/YeastPathways_SO4ASSIM-PWY.ttl
@@ -9,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -316,7 +316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "assimilatory sulfate reduction I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -721,7 +721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1122,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1219,7 +1219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1288,7 +1288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1363,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1447,7 +1447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1480,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1541,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1557,7 +1557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1590,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1615,7 +1615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1676,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1703,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1719,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1735,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1771,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_SPHINGOLIPID-SYN-PWY-1.ttl
+++ b/models/YeastPathways_SPHINGOLIPID-SYN-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,23 +72,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57287_RXN3O-328>
 ] .
-
-<http://model.geneontology.org/e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0030148>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -100,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,11 +96,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_62682>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -127,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -178,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -279,33 +265,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -318,11 +287,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +299,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042>
+          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -352,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -449,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -462,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,12 +439,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_61910_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_DHS-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -484,16 +464,24 @@
 <http://identifiers.org/sgd/S000002702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000066_reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_25168_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-680> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_25168_RXN3O-663>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -503,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,34 +502,26 @@
           <http://model.geneontology.org/CHEBI_30616_SPHINGANINE-KINASE-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-680> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663>
-] .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_BFO_0000066_reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002333_CPLX3O-78_RXN3O-328_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,23 +580,12 @@
           <http://model.geneontology.org/RXN3O-504>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,14 +640,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_CHEBI_31998_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004758>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -691,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +759,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN> ;
+                <http://model.geneontology.org/CHEBI_31998_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_10283_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -792,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -839,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,29 +827,23 @@
           <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
 ] .
 
-<http://model.geneontology.org/5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_62682_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
         a       <http://identifiers.org/sgd/S000004913> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -884,7 +855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,30 +892,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-KINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002233_CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,12 +907,48 @@
           <http://model.geneontology.org/CHEBI_15378_SERINE-C-PALMITOYLTRANSFERASE-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-KINASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DHS-PHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-KINASE-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_61910_RXN3O-328>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61910> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a very long chain fatty acyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_15378_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -998,7 +986,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002413_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1022,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,16 +1051,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_60245_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1148,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,6 +1218,23 @@
           <http://model.geneontology.org/YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_62682_RXN3O-680>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_62682> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
@@ -1227,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1261,7 +1277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1441,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1472,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,15 +1580,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
+                <http://model.geneontology.org/CHEBI_25168_RXN3O-663> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-680> , <http://model.geneontology.org/438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-680> , <http://model.geneontology.org/CHEBI_62682_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,23 +1596,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-663_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_SERINE-C-PALMITOYLTRANSFERASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1608,7 +1624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1624,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1639,7 +1655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1655,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1694,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,7 +1726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1726,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1741,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1757,7 +1773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1803,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1848,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1862,7 +1878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,7 +1897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1908,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1919,14 +1935,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1936,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1949,11 +1962,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_31998_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1961,7 +1974,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042>
+          <http://model.geneontology.org/CHEBI_31998_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-4042_location_lociGO_0005829>
@@ -1969,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1981,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +2008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2050,7 +2063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,7 +2082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2088,7 +2101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,7 +2123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,6 +2133,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_31998_RXN3O-328>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_31998_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008117>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2132,7 +2156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2161,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,29 +2193,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_CHEBI_31998_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002413_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2208,7 +2237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2221,17 +2250,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' 'null' 'a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002411_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002413_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2246,7 +2275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2310,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2322,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2344,15 +2373,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15378_RXN3O-4042> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_31998_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> , <http://model.geneontology.org/dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042> ;
+                <http://model.geneontology.org/CHEBI_31998_RXN3O-4042> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-581> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2369,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2400,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2430,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2444,7 +2473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2464,7 +2493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2483,7 +2512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2502,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2518,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2529,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2541,7 +2570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2554,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2567,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2603,7 +2632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2625,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2643,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2653,17 +2682,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'a phytoceramide + 2 a ferrocytochrome <i>b<SUB>5</SUB></i> + oxygen + 2 H<SUP>+</SUP> &rarr; a (2'R)-2'-hydroxy-phytoceramide + 2 a ferricytochrome <i>b<sub>5</sub></i> + H<sub>2</sub>O' 'null' 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002411_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002413_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -2682,7 +2711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2695,28 +2724,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_16749_RXN3O-680>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19753> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'L-serine + palmitoyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 3-dehydrosphinganine + coenzyme A' 'null' 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002413_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2726,7 +2757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2737,24 +2768,22 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-1380>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'L-serine + palmitoyl-CoA + H<SUP>+</SUP> &rarr; CO<SUB>2</SUB> + 3-dehydrosphinganine + coenzyme A' 'null' 'D-<i>erythro</i>-sphinganine + NADP<sup>+</sup> &larr; 3-dehydrosphinganine + NADPH + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002413_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
-] .
+<http://model.geneontology.org/CHEBI_16749_RXN3O-680>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19753> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2768,7 +2797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2780,11 +2809,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_CHEBI_62682_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2792,7 +2821,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680>
+          <http://model.geneontology.org/CHEBI_62682_RXN3O-680>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2803,7 +2832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2823,24 +2852,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19967> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2850,7 +2868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2866,18 +2884,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_25168>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2890,17 +2911,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
+                <http://model.geneontology.org/CHEBI_60245_RXN3O-581> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
+                <http://model.geneontology.org/CHEBI_25168_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-680> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,11 +2933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_61910_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2924,7 +2945,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN>
+          <http://model.geneontology.org/CHEBI_61910_RXN3O-328>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_15378_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
@@ -2932,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2946,7 +2967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2965,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2976,7 +2997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2987,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2998,7 +3019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3013,7 +3034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,29 +3047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002411_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3059,21 +3058,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3084,7 +3080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3095,7 +3091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3109,7 +3105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,28 +3121,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a very long chain fatty acyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_10283>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3159,7 +3138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3174,11 +3153,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_CHEBI_60245_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3186,7 +3165,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581>
+          <http://model.geneontology.org/CHEBI_60245_RXN3O-581>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -3198,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3215,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3231,7 +3210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3251,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3267,7 +3246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,17 +3257,6 @@
           <http://model.geneontology.org/MONOMER3O-419_DHS-PHOSPHATASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN3O-328>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3298,7 +3266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3311,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3325,7 +3293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3344,7 +3312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3360,7 +3328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3375,7 +3343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3391,7 +3359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3407,7 +3375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3419,7 +3387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3435,7 +3403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3449,7 +3417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3468,7 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3479,7 +3447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3507,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3523,7 +3491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3539,7 +3507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3564,13 +3532,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1BiochemicalReaction19658> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002413_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-1380>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3581,13 +3560,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19598> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_25168_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3597,7 +3587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3617,11 +3607,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_31998_CERAMIDASE-YEAST-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_31998> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3633,7 +3640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3649,7 +3656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3660,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3674,7 +3681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3711,7 +3718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sphingolipid biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3727,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3737,11 +3744,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_60245_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3749,7 +3756,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/242f0833-10e5-4c4b-8e31-fb72f427569b_RXN3O-581>
+          <http://model.geneontology.org/CHEBI_60245_RXN3O-581>
 ] .
 
 <http://identifiers.org/sgd/S000003670>
@@ -3766,7 +3773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3785,7 +3792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3799,7 +3806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3818,7 +3825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3837,7 +3844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3851,7 +3858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,26 +3869,15 @@
           <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_CHEBI_31998_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3889,7 +3885,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CERAMIDASE-YEAST-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN>
+          <http://model.geneontology.org/CHEBI_31998_CERAMIDASE-YEAST-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002233_CHEBI_64124_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
@@ -3897,7 +3893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3911,7 +3907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3927,7 +3923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3938,7 +3934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3949,7 +3945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3959,11 +3955,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_CERAMIDASE-YEAST-RXN_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3967,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328>
+          <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3982,7 +3978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3993,6 +3989,23 @@
           <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_25168_RXN3O-663>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_25168> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
@@ -4001,7 +4014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4017,7 +4030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4034,7 +4047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4057,7 +4070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4073,7 +4086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4084,23 +4097,12 @@
           <http://model.geneontology.org/SGD_S000000240_CPLX3O-383_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002411_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002413_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4114,7 +4116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4130,7 +4132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4144,7 +4146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4163,7 +4165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4182,7 +4184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4199,7 +4201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4229,7 +4231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4245,7 +4247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4254,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4269,7 +4271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4285,7 +4287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4304,7 +4306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4318,7 +4320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4332,7 +4334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4351,7 +4353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4370,7 +4372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4381,7 +4383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4395,7 +4397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4409,7 +4411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4420,6 +4422,23 @@
           <http://model.geneontology.org/YLR260W-MONOMER_RXN3O-458_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_60245_RXN3O-581>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60245> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001761> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4427,7 +4446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4442,7 +4461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4455,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4469,7 +4488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4485,7 +4504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4499,7 +4518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4513,7 +4532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4536,7 +4555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4549,7 +4568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4563,7 +4582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4588,7 +4607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4607,7 +4626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4623,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4638,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4654,7 +4673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4673,7 +4692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4689,18 +4708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_dc05b1a8-008a-4e51-a82e-4892afe00367_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4715,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4728,7 +4736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4745,7 +4753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4756,9 +4764,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-663>
 ] .
 
-<http://model.geneontology.org/2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/YLR260W-MONOMER_SPHINGANINE-KINASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000004250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4766,24 +4771,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1Protein19620> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_2b95a6d9-8114-4f17-bf85-1563aa4f9f7b_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4794,7 +4788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4807,7 +4801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4820,7 +4814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4836,7 +4830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4858,7 +4852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4877,7 +4871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4893,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4902,7 +4896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4916,7 +4910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4934,7 +4928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4953,7 +4947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4973,7 +4967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4989,7 +4983,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_CHEBI_60245_RXN3O-581_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5003,7 +5008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5023,7 +5028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5042,7 +5047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5062,17 +5067,17 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/36f3c8a6-9b43-4845-85af-c90ea5af8c4f_RXN3O-4042> , <http://model.geneontology.org/CHEBI_16749_RXN3O-581> ;
+                <http://model.geneontology.org/CHEBI_31998_RXN3O-4042> , <http://model.geneontology.org/CHEBI_16749_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/5f5cbec0-b1e0-41bc-9694-9cd97dc00d44_RXN3O-581> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/CHEBI_60245_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-663> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5089,7 +5094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5105,7 +5110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5122,7 +5127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5141,7 +5146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5157,7 +5162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5172,7 +5177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5185,7 +5190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5196,7 +5201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5204,17 +5209,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" , "Provides Input For Rule. The relation 'a (2'R)-2'-hydroxy-phytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; an inositol-phospho-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' 'null' 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002411_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002413_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -5229,7 +5234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5245,7 +5250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5256,7 +5261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5272,11 +5277,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_31998_RXN3O-4042_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5284,7 +5289,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042>
+          <http://model.geneontology.org/CHEBI_31998_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_YeastPathways_SPHINGOLIPID-SYN-PWY-1/YeastPathways_SPHINGOLIPID-SYN-PWY-1_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
@@ -5292,7 +5297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5306,7 +5311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5322,7 +5327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5336,7 +5341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5355,7 +5360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5371,18 +5376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002411_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5393,7 +5387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5410,7 +5404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5426,7 +5420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5442,7 +5436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5457,7 +5451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5473,7 +5467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5489,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5497,17 +5491,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_438a90e8-4e1e-40bf-8a4f-c5350ed33b3f_RXN3O-680_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-1380>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5528,13 +5511,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1BiochemicalReaction19893> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://purl.obolibrary.org/obo/CHEBI_61910>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_31998_RXN3O-328>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_31998> ;
@@ -5545,7 +5531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5564,7 +5550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5583,28 +5569,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/0e189dd8-b35e-4155-9183-7becc8f1dedd_CERAMIDASE-YEAST-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5614,7 +5583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5633,7 +5602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5649,18 +5618,46 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_25168_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_31998_RXN3O-4042>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_31998> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000000240_CPLX3O-383_component_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5674,7 +5671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5693,7 +5690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5709,7 +5706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5720,7 +5717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5731,7 +5728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5742,7 +5739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5757,7 +5754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5769,11 +5766,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_25168_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5781,7 +5778,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58189_RXN3O-663>
+          <http://model.geneontology.org/CHEBI_25168_RXN3O-663>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_FERRICYTOCHROME-B5_RXN3O-1380_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1>
@@ -5789,7 +5786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5800,7 +5797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5811,7 +5808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5825,7 +5822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5841,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5862,7 +5859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5875,7 +5872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5886,7 +5883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5902,7 +5899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5921,7 +5918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5936,11 +5933,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_CHEBI_58189_RXN3O-663_SGD_PWY_YeastPathways_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5948,7 +5945,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e06c821f-70f9-4e37-9c61-cf37e420cd66_RXN3O-663>
+          <http://model.geneontology.org/CHEBI_58189_RXN3O-663>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-663>
@@ -5960,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5977,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5994,7 +5991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6010,7 +6007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6024,6 +6021,9 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_60245>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
@@ -6032,7 +6032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6052,7 +6052,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-328_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9941306a-9bdb-4bd1-a9f4-2e3e70daeb9e_RXN3O-328> , <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> ;
+                <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_61910_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_RXN3O-328> , <http://model.geneontology.org/CHEBI_57287_RXN3O-328> , <http://model.geneontology.org/CHEBI_31998_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -6064,7 +6064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6080,7 +6080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6096,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6107,7 +6107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6118,7 +6118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6129,7 +6129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6143,7 +6143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6159,7 +6159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6174,7 +6174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_SUCUTIL-PWY-2.ttl
+++ b/models/YeastPathways_SUCUTIL-PWY-2.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sucrose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_TCA-EUK-PWY.ttl
+++ b/models/YeastPathways_TCA-EUK-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -480,7 +480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -825,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -994,7 +994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,7 +1341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,17 +1371,6 @@
           <http://model.geneontology.org/SGD_S000005668_CPLX3O-690_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TCA-EUK-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
@@ -1390,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,6 +1390,9 @@
           <http://model.geneontology.org/CHEBI_57292_2OXOGLUTARATEDEH-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1410,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,15 +1413,23 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002333_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TCA-EUK-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1570,7 +1570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1601,7 +1601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1631,30 +1631,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CITSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1665,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,12 +1654,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_MALATE-DEH-RXN_SGD_PWY_YeastPathways_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CITSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16452_MALATE-DEH-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000066_reaction_ACONITATEDEHYDR-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1810,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,7 +1849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1985,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2002,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2016,7 +2016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2032,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2050,7 +2050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2115,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2131,7 +2131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,7 +2169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2192,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2208,7 +2208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,7 +2318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2360,7 +2360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2373,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2387,7 +2387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2461,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2474,7 +2474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2520,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2533,7 +2533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2551,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2568,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2584,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2595,7 +2595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2606,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2620,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2639,7 +2639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2659,7 +2659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2675,7 +2675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2686,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2698,7 +2698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2714,7 +2714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2748,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2761,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2772,7 +2772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2787,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,7 +2800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2811,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2822,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2836,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2866,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2886,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2899,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2911,7 +2911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2927,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2944,7 +2944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2974,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2997,7 +2997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3013,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3024,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3038,7 +3038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3054,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3066,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3086,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3099,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3121,7 +3121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3135,7 +3135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3151,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3164,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3180,7 +3180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3225,7 +3225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3266,7 +3266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3279,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3299,7 +3299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3318,7 +3318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3334,7 +3334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3349,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3365,7 +3365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3381,7 +3381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3414,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3430,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3471,7 +3471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3501,7 +3501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,7 +3521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3534,7 +3534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3545,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3558,7 +3558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3577,7 +3577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3588,7 +3588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3602,7 +3602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3618,7 +3618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3629,7 +3629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3640,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3651,7 +3651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3662,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3676,7 +3676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3692,7 +3692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3703,7 +3703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3717,7 +3717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3736,7 +3736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3755,7 +3755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3772,7 +3772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3791,7 +3791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3802,7 +3802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3816,7 +3816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3832,7 +3832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3847,7 +3847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "TCA cycle, aerobic respiration - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3863,7 +3863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3898,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3911,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3925,7 +3925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3941,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3955,7 +3955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3986,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3999,7 +3999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4010,7 +4010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4024,7 +4024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4040,7 +4040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4051,7 +4051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4066,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4082,7 +4082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4098,7 +4098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4113,7 +4113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4130,7 +4130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4146,7 +4146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4162,7 +4162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4176,7 +4176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4192,7 +4192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4205,7 +4205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4218,7 +4218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4232,7 +4232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4251,7 +4251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4264,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4280,7 +4280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4305,7 +4305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4324,7 +4324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4340,7 +4340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4353,7 +4353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,7 +4366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4377,7 +4377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4389,7 +4389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4422,7 +4422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4439,7 +4439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4455,7 +4455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4467,7 +4467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4483,7 +4483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4494,7 +4494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4511,7 +4511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4525,15 +4525,6 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
@@ -4542,7 +4533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4553,12 +4544,21 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002333_YCR005C-MONOMER_CITSYN-RXN_controller_SGD_PWY_YeastPathways_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4569,7 +4569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4580,7 +4580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4594,7 +4594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4613,7 +4613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4634,7 +4634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4656,7 +4656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4672,7 +4672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4690,7 +4690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4706,7 +4706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4722,7 +4722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4733,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4747,7 +4747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4766,7 +4766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4782,7 +4782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4794,7 +4794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4822,7 +4822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4841,7 +4841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4855,7 +4855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4869,7 +4869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4885,7 +4885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4899,7 +4899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4918,7 +4918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4938,7 +4938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4951,7 +4951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4966,7 +4966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4982,7 +4982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4998,7 +4998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5012,7 +5012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5034,7 +5034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5053,7 +5053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5072,7 +5072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5091,7 +5091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5110,7 +5110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5125,7 +5125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5141,7 +5141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5157,7 +5157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5168,7 +5168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -5177,7 +5177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5191,7 +5191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5207,7 +5207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_THIOREDOX-PWY.ttl
+++ b/models/YeastPathways_THIOREDOX-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THIOREDOXIN-REDUCT-NADPH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/Red-Thioredoxin_THIOREDOXIN-RXN> , <http://model.geneontology.org/CHEBI_57783_THIOREDOXIN-REDUCT-NADPH-RXN> , <http://model.geneontology.org/CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN> ;
+                <http://model.geneontology.org/Red-Thioredoxin_THIOREDOXIN-RXN> , <http://model.geneontology.org/CHEBI_15378_THIOREDOXIN-REDUCT-NADPH-RXN> , <http://model.geneontology.org/CHEBI_57783_THIOREDOXIN-REDUCT-NADPH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/Red-Thioredoxin_THIOREDOXIN-REDUCT-NADPH-RXN> , <http://model.geneontology.org/CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thioredoxin pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_THREOCAT2-PWY.ttl
+++ b/models/YeastPathways_THREOCAT2-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -642,7 +642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -967,7 +967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,7 +1036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,7 +1055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1132,7 +1132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1282,7 +1282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1301,7 +1301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1370,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1473,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1512,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1562,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1575,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1589,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1675,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1711,7 +1711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1725,7 +1725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1816,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1830,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1873,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1923,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,7 +1939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1972,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +1986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2012,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,7 +2028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2047,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2063,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2142,7 +2142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2172,7 +2172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2208,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2219,7 +2219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2272,7 +2272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2302,7 +2302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2338,7 +2338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2365,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2379,7 +2379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2395,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2426,7 +2426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2446,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2459,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2473,7 +2473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,7 +2492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2520,7 +2520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2588,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,7 +2604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2624,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2637,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2657,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2682,7 +2682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2698,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2707,7 +2707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2724,7 +2724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2754,7 +2754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2770,7 +2770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2784,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2798,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2812,7 +2812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2831,7 +2831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2857,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2870,7 +2870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2881,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2895,7 +2895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2915,7 +2915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2931,7 +2931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2951,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2967,7 +2967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2994,7 +2994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3008,7 +3008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3024,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3049,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3065,7 +3065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3085,7 +3085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3102,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3115,7 +3115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3126,7 +3126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3143,7 +3143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3154,7 +3154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3165,7 +3165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3182,7 +3182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3217,7 +3217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3234,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3250,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3281,7 +3281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,7 +3300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3320,7 +3320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3336,7 +3336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3352,7 +3352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3363,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3377,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3405,7 +3405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3419,7 +3419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3439,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3456,7 +3456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "threonine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3469,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3484,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3497,7 +3497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3509,7 +3509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3525,7 +3525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3539,7 +3539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3555,7 +3555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3585,7 +3585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3601,7 +3601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3617,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3634,7 +3634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3670,7 +3670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3686,7 +3686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3697,7 +3697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3712,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3725,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3739,7 +3739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3762,7 +3762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3775,7 +3775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3789,7 +3789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3807,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3840,7 +3840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3859,7 +3859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3875,7 +3875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3886,7 +3886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3910,7 +3910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3927,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3943,7 +3943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3963,7 +3963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3982,7 +3982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3998,7 +3998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4009,7 +4009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4023,7 +4023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4043,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4059,7 +4059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4070,7 +4070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4081,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4095,7 +4095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_THRESYN-PWY.ttl
+++ b/models/YeastPathways_THRESYN-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -500,7 +500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -967,7 +967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,24 +978,16 @@
           <http://model.geneontology.org/YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ASPAMINOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
-] .
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1006,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,23 +1006,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_RO_0002234_CHEBI_57926_THRESYN-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY_YeastPathways_THRESYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ASPAMINOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
+] .
 
 <http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY_YeastPathways_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1110,7 +1110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,18 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1220,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THRESYN-RXN_BFO_0000050_YeastPathways_THRESYN-PWY/YeastPathways_THRESYN-PWY_SGD_PWY_YeastPathways_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,7 +1422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1511,7 +1511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,7 +1708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1823,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1850,7 +1850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1864,7 +1864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1908,7 +1908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1938,7 +1938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1968,7 +1968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2004,7 +2004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,7 +2070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2096,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,7 +2127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2154,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2195,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2209,7 +2209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2225,7 +2225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2253,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2266,7 +2266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2277,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2291,7 +2291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2310,7 +2310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2326,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2367,7 +2367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2403,7 +2403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2428,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2439,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_TREDEG-YEAST-PWY.ttl
+++ b/models/YeastPathways_TREDEG-YEAST-PWY.ttl
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -417,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_TRESYN-PWY.ttl
+++ b/models/YeastPathways_TRESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -276,17 +287,6 @@
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58429_TREHALOSE6PSYN-RXN_SGD_PWY_YeastPathways_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -355,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -661,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_TRIGLSYN-PWY.ttl
+++ b/models/YeastPathways_TRIGLSYN-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diacylglycerol and triacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -119,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,21 +193,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_RXN-1641_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIACYLGLYCEROL-O-ACYLTRANSFERASE-RXN_RO_0002233_CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,12 +221,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_RXN-1641_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-12959_RO_0002233_CHEBI_37563_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,13 +634,13 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/MONOMER3O-4125_PHOSPHATIDATE-PHOSPHATASE-RXN_controller>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://identifiers.org/sgd/S000004775> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "phosphatidate phosphatase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,6 +1026,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN-1641>
 ] .
+
+<http://identifiers.org/sgd/S000004775>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29089>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1039,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1107,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,7 +1126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1145,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1242,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1289,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1321,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1334,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1358,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1380,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1397,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1436,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1511,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1522,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1569,9 +1572,6 @@
           <http://model.geneontology.org/CHEBI_29089_RXN-12959>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
@@ -1580,7 +1580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1616,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1706,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1719,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1750,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1769,7 +1769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1785,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1814,7 +1814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1873,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1892,7 +1892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1901,6 +1901,25 @@
           <http://model.geneontology.org/RXN-1381> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YeastPathways_TRIGLSYN-PWY/YeastPathways_TRIGLSYN-PWY>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHATIDATE-PHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16975_RXN-1381>
@@ -1912,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1920,31 +1939,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002234_CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN_SGD_PWY_YeastPathways_TRIGLSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHATIDATE-PHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDATE-PHOSPHATASE-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDATE-PHOSPHATASE-RXN_RO_0002413_RXN-12959_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1965,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1985,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +2004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2050,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2064,7 +2064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,17 +2078,6 @@
 <http://purl.obolibrary.org/obo/GO_0046027>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_17984_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_17815_PHOSPHATIDATE-PHOSPHATASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17815> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2098,13 +2087,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRIGLSYN-PWYSmallMolecule56268> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-1381_RO_0002233_CHEBI_17984_RXN-1381_SGD_PWY_YeastPathways_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2114,7 +2114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2133,7 +2133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2153,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2169,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2185,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2199,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2213,7 +2213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2229,7 +2229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2243,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2290,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2301,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2313,7 +2313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2332,7 +2332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2352,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2365,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2379,7 +2379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,7 +2399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2415,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2428,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2444,7 +2444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2464,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,7 +2480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2499,7 +2499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2519,7 +2519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,7 +2568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2618,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_TRPSYN-PWY-1.ttl
+++ b/models/YeastPathways_TRPSYN-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -755,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -926,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1232,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1385,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1512,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1574,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1590,7 +1590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1664,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1702,7 +1702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1718,7 +1718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1732,7 +1732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1754,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1779,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,7 +1808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1886,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1909,7 +1909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1944,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +1973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2003,7 +2003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2022,7 +2022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2037,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_TRYPTOPHAN-DEGRADATION-1.ttl
+++ b/models/YeastPathways_TRYPTOPHAN-DEGRADATION-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,7 +208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1067,18 +1067,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,12 +1103,12 @@
           <http://model.geneontology.org/YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.13.11.6-RXN_RO_0002333_YJR025C-MONOMER_1.13.11.6-RXN_controller_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000066_reaction_ARYLFORMAMIDASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1311,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1388,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1411,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1478,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1503,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1533,7 +1533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1610,7 +1610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1646,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1692,7 +1692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,7 +1711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1742,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1769,7 +1769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1853,7 +1853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1886,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,7 +1905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1925,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1938,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1952,7 +1952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1972,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2032,7 +2032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2062,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2081,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2092,6 +2092,17 @@
           <http://model.geneontology.org/CHEBI_456215_NAD-SYNTH-GLN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" , "Provides Input For Rule. The relation '<i>N</i>-Formyl-L-kynurenine + H<sub>2</sub>O &rarr; L-kynurenine + formate + H<SUP>+</SUP>' 'null' 'L-kynurenine + NADPH + oxygen + H<SUP>+</SUP> &rarr; 3-hydroxy-L-kynurenine + NADP<sup>+</sup> + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -2100,7 +2111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,23 +2122,12 @@
           <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5721_RO_0002413_QUINOPRIBOTRANS-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002233_CHEBI_58125_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2138,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2149,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2160,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2213,7 +2213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2232,7 +2232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,7 +2251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,7 +2270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2307,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2329,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2382,7 +2382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,7 +2420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2436,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2465,7 +2465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2484,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2498,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2513,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2526,18 +2526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2552,13 +2541,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRYPTOPHAN-DEGRADATION-1SmallMolecule66735> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_15377_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2568,7 +2568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2584,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2599,7 +2599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2615,7 +2615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2631,7 +2631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2692,7 +2692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,7 +2720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2736,7 +2736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2747,7 +2747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2762,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2775,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2791,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2807,7 +2807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2854,7 +2854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2870,7 +2870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2892,7 +2892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2908,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2920,7 +2920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2936,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2950,7 +2950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2961,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3003,7 +3003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3037,7 +3037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3055,7 +3055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3071,7 +3071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3115,7 +3115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3131,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3162,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3178,7 +3178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,7 +3197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3213,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3227,7 +3227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3283,23 +3283,23 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_BFO_0000066_reaction_3-HYDROXY-KYNURENINASE-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002233_CHEBI_57959_ARYLFORMAMIDASE-RXN_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3314,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3336,7 +3336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3350,7 +3350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,7 +3369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3385,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3399,7 +3399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3419,7 +3419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3435,7 +3435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3458,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3475,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation III (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3491,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3503,18 +3503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3522,6 +3511,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_YeastPathways_TRYPTOPHAN-DEGRADATION-1/YeastPathways_TRYPTOPHAN-DEGRADATION-1_SGD_PWY_YeastPathways_TRYPTOPHAN-DEGRADATION-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3531,7 +3531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3550,7 +3550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3569,7 +3569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3588,7 +3588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3606,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3619,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3630,7 +3630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3644,7 +3644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3662,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,7 +3694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3724,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3738,7 +3738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3764,7 +3764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3781,7 +3781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3794,7 +3794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3809,7 +3809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3822,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3834,7 +3834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_UDPNAGSYN-YEAST-PWY.ttl
+++ b/models/YeastPathways_UDPNAGSYN-YEAST-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -60,11 +60,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_29888_NAG1P-URIDYLTRANS-RXN>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -262,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -283,11 +294,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,21 +306,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
-
-<http://model.geneontology.org/3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +325,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
@@ -329,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -354,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -404,14 +412,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -423,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -496,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UDP-N-acetylglucosamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -518,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,17 +582,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PHOSACETYLGLUCOSAMINEMUT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002411_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001587>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -603,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,11 +612,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +624,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN>
+          <http://model.geneontology.org/CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002234_CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
@@ -638,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,17 +710,6 @@
           <http://model.geneontology.org/CHEBI_15378_NAG1P-URIDYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/YFL017C-MONOMER_GLUCOSAMINEPNACETYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000001877> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -734,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -779,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -921,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -997,39 +980,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/RO_0002411>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-glucosamine 6-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1039,17 +1002,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" , "Provides Input For Rule. The relation '&beta;-D-fructofuranose 6-phosphate + L-glutamine &harr; D-glucosamine 6-phosphate + L-glutamate' 'null' 'D-glucosamine 6-phosphate + acetyl-CoA &rarr; <i>N</i>-acetyl-D-glucosamine 6-phosphate + coenzyme A + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002411_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002413_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1067,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,15 +1052,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/2bc4a77d-96f2-4dec-843f-938795185fdf_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1117,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,6 +1091,17 @@
 <http://identifiers.org/sgd/S000001877>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_57705_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1136,7 +1110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1147,16 +1121,22 @@
           <http://model.geneontology.org/reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002234_CHEBI_57705_NAG1P-URIDYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15873> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-glucosamine 6-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1166,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,12 +1176,15 @@
           <http://model.geneontology.org/CHEBI_57705_NAG1P-URIDYLTRANS-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15873>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_RO_0002333_YEL058W-MONOMER_PHOSACETYLGLUCOSAMINEMUT-RXN_controller_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1218,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1266,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1304,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1341,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1357,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1435,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/3a0ad624-fec2-4287-8b38-9083a590963a_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_15873_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1462,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1478,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,6 +1475,17 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002413_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_PWY_YeastPathways_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
@@ -1500,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_VALSYN-PWY.ttl
+++ b/models/YeastPathways_VALSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,23 +352,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_BFO_0000050_YeastPathways_VALSYN-PWY/YeastPathways_VALSYN-PWY_SGD_PWY_YeastPathways_VALSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_ACETOLACTREDUCTOISOM-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -948,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -968,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-valine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1118,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,9 +1294,6 @@
           <http://model.geneontology.org/reaction_ACETOLACTSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/YLR355C-MONOMER_ACETOLACTREDUCTOISOM-RXN_controller>
         a       <http://identifiers.org/sgd/S000004347> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1304,13 +1301,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=VALSYN-PWYProtein58183> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1320,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1365,7 +1365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1404,7 +1404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1418,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1551,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,7 +1612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_YEAST-4AMINOBUTMETAB-PWY.ttl
+++ b/models/YeastPathways_YEAST-4AMINOBUTMETAB-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobutyrate degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -538,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,23 +679,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GABATRANSAM-RXN_RO_0002333_YGR019W-MONOMER_GABATRANSAM-RXN_controller_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-5293_BFO_0000066_reaction_RXN0-5293_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-4AMINOBUTMETAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT.ttl
+++ b/models/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -80,23 +80,12 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-14122_RO_0002234_CHEBI_60471_RXN-14122_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -106,11 +95,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +107,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
+          <http://model.geneontology.org/CHEBI_20502_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-14122_BFO_0000050_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT/YeastPathways_YEAST-DE-NOVO-PYRMID-DNT_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
@@ -126,11 +115,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_20502_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_20502> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -140,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,9 +309,6 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -314,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -453,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -562,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -571,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,6 +641,23 @@
           <http://model.geneontology.org/reaction_UDPREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_61555_DUDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_61555> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -647,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -737,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -770,18 +790,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57451>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -799,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -897,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,11 +941,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_246422_DUTP-PYROP-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +953,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -941,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -969,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,7 +1183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,9 +1233,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN> , <http://model.geneontology.org/c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_DUTP-PYROP-RXN> , <http://model.geneontology.org/CHEBI_20502_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1220,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1233,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1244,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1269,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1320,7 +1343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1505,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1536,7 +1559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1569,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1638,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1657,7 +1680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1684,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1693,28 +1716,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0008829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1730,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,7 +1758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1785,7 +1791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1816,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1831,11 +1837,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1843,7 +1849,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_57451_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
@@ -1854,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1879,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1904,7 +1910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1942,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1976,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +2001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,7 +2017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2052,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2064,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2087,7 +2093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2100,7 +2106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2115,7 +2121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2131,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2157,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2173,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2189,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2204,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2221,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2237,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2271,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2290,7 +2296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2321,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2348,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2364,7 +2370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2413,7 +2419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2432,7 +2438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2482,7 +2488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2502,7 +2508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2515,7 +2521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2527,7 +2533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2545,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2553,16 +2559,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_20502>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2572,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2605,7 +2603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2616,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2644,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2656,11 +2654,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_63528_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2668,7 +2666,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a8dc286c-7346-4926-b1c5-f6950f436944_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829>
@@ -2676,7 +2674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2694,7 +2692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2710,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2725,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2742,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2758,7 +2756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,7 +2772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2785,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2797,7 +2795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2813,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2827,7 +2825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2843,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2857,7 +2855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2911,7 +2909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2920,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2931,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2945,7 +2943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2968,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2984,7 +2982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3000,7 +2998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3015,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3031,7 +3029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3046,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3059,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3073,7 +3071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3092,7 +3090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3115,7 +3113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3134,7 +3132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,26 +3148,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/c7a9b469-934d-4de6-b320-7f1dc027edfb_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3179,7 +3160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3199,7 +3180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3212,7 +3193,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_CHEBI_57451_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3226,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3262,7 +3254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3292,7 +3284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,7 +3309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3333,7 +3325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3347,7 +3339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3366,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3380,7 +3372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3410,7 +3402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3426,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3440,7 +3432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3459,7 +3451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3475,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3486,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3497,7 +3489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3511,7 +3503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3530,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3548,7 +3540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3568,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3587,7 +3579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3603,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3615,7 +3607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3635,7 +3627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3652,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3671,7 +3663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3690,7 +3682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3712,7 +3704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3732,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3745,7 +3737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3760,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3779,7 +3771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3795,7 +3787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3804,7 +3796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3815,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3827,7 +3819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3838,12 +3830,23 @@
           <http://model.geneontology.org/CHEBI_60471_UDPREDUCT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_CHEBI_20502_THYMIDYLATESYN-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DCDPKIN-RXN_RO_0002413_DCTP-DEAM-RXN_SGD_PWY_YeastPathways_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3857,7 +3860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3880,7 +3883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3896,7 +3899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3912,7 +3915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3925,7 +3928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3941,7 +3944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3952,7 +3955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3966,7 +3969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3980,7 +3983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,7 +4002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4015,7 +4018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -4024,7 +4027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4038,7 +4041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4068,7 +4071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4084,7 +4087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4104,7 +4107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4121,7 +4124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4137,7 +4140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4153,7 +4156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4167,7 +4170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4183,7 +4186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4197,7 +4200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4213,7 +4216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4224,7 +4227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4238,7 +4241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4266,7 +4269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4282,7 +4285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4296,7 +4299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4314,7 +4317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4327,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4338,7 +4341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4352,7 +4355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4368,7 +4371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4379,7 +4382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_YEAST-FAO-PWY.ttl
+++ b/models/YeastPathways_YEAST-FAO-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -105,17 +105,6 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004300> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -125,7 +114,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
+                <http://model.geneontology.org/74f3b663-dc41-4fed-9386-c0baacb1675d_ENOYL-COA-DELTA-ISOM-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -135,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,17 +173,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+          "Provides Input For Rule. The relation 'a 2,3,4-saturated fatty acid + ATP + coenzyme A &rarr; a 2,3,4-saturated fatty acyl CoA + AMP + diphosphate' 'null' 'a 2,3,4-saturated fatty acyl CoA + oxygen &rarr; a <i>trans</i>-2-enoyl-CoA + hydrogen peroxide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002413_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACYLCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -210,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,12 +236,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_27773>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_57287_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,24 +302,16 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000066_reaction_ACYLCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACYLCOASYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ACYLCOASYN-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YMR246W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/ACYLCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004467> ;
@@ -340,15 +324,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_71627_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> , <http://model.geneontology.org/bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_77332_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-11026> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,22 +345,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YMR246W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_BFO_0000066_reaction_ACYLCOASYN-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACYLCOASYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ACYLCOASYN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001717> ;
@@ -385,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,13 +409,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYProtein59500> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_68807a3d-8d26-46ea-87eb-244522db6552_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -450,13 +453,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYBiochemicalReaction59535> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_CHEBI_77332_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000001422>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -465,11 +479,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_68807a3d-8d26-46ea-87eb-244522db6552_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +491,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026>
+          <http://model.geneontology.org/68807a3d-8d26-46ea-87eb-244522db6552_RXN-11026>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
@@ -489,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -563,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -573,11 +587,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_CHEBI_27773_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +599,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/CHEBI_27773_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller>
@@ -595,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -609,6 +623,17 @@
 <http://identifiers.org/sgd/S000000245>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_74f3b663-dc41-4fed-9386-c0baacb1675d_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000005844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -619,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,16 +652,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_CHEBI_27773_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000066_reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_77332>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0003857>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -649,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,11 +703,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_74f3b663-dc41-4fed-9386-c0baacb1675d_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +715,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/74f3b663-dc41-4fed-9386-c0baacb1675d_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -690,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -719,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -743,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -751,6 +790,17 @@
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_71627_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -760,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,17 +821,6 @@
           <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_71627_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
@@ -790,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,18 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -832,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -847,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +888,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002413_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -875,7 +914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -925,11 +964,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59577> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_27773_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_27773> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (3Z)-alk-3-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -938,28 +994,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -968,11 +1007,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_CHEBI_77332_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +1019,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_77332_ACYLCOASYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -991,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1017,11 +1056,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_77332_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1068,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACYLCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN>
+          <http://model.geneontology.org/CHEBI_77332_ACYLCOASYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15455_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
@@ -1037,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1065,17 +1104,17 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+          "Provides Input For Rule. The relation 'a 2,3,4-saturated fatty acyl CoA + acetyl-CoA &larr; a 3-oxoacyl-CoA + coenzyme A' 'null' 'a 2,3,4-saturated fatty acyl CoA + oxygen &rarr; a <i>trans</i>-2-enoyl-CoA + hydrogen peroxide' was inferred because:\n reaction1 has an output that is an input of reaction 2. " , "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002413_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
@@ -1087,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1101,7 +1140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,6 +1177,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_71627>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002413_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1152,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1208,13 +1258,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59407> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_52f15c9b-5c22-4cd7-9fc2-83c459fde5ce_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000004860> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1223,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,15 +1340,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_CHEBI_15377_ENOYL-COA-HYDRAT-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid oxidation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1350,30 +1408,11 @@
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15489_OHACYL-COA-DEHYDROG-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YER015W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1384,21 +1423,57 @@
           <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_CHEBI_15489_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15489_OHACYL-COA-DEHYDROG-RXN>
+] .
+
 <http://model.geneontology.org/reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/52f15c9b-5c22-4cd7-9fc2-83c459fde5ce_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_57540_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1418,7 +1493,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_77332_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1432,7 +1518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,15 +1529,18 @@
           <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/74f3b663-dc41-4fed-9386-c0baacb1675d_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_52f15c9b-5c22-4cd7-9fc2-83c459fde5ce_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,7 +1548,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/52f15c9b-5c22-4cd7-9fc2-83c459fde5ce_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN>
@@ -1471,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1484,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1508,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1536,23 +1625,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004467>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1562,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1634,15 +1712,21 @@
 <http://purl.obolibrary.org/obo/GO_0019395>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000000817>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_15489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_CHEBI_77332_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1650,21 +1734,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN>
+          <http://model.geneontology.org/CHEBI_77332_KETOACYLCOATHIOL-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_15489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000000817>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002333_YER015W-MONOMER_ACYLCOASYN-RXN_controller_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1678,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,7 +1775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1734,7 +1812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1770,6 +1848,17 @@
 <http://identifiers.org/sgd/S000005706>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000066_reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
@@ -1778,7 +1867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,51 +1878,6 @@
           <http://model.geneontology.org/YeastPathways_YEAST-FAO-PWY/YeastPathways_YEAST-FAO-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_BFO_0000066_reaction_ENOYL-COA-HYDRAT-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/bc8ee67c-a712-45f7-92a3-938457e0f60c_ACYLCOASYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1843,16 +1887,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59369> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/KETOACYLCOATHIOL-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003988> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1865,15 +1906,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15489_OHACYL-COA-DEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57287_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN> ;
+                <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_77332_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YIL160C-MONOMER_KETOACYLCOATHIOL-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002411>
+        <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-11026> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1926,7 +1967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1945,7 +1986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,11 +1997,39 @@
           <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_CHEBI_77332_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004165>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003173>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/68807a3d-8d26-46ea-87eb-244522db6552_RXN-11026>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1970,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2020,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2031,17 +2100,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2050,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2082,9 +2140,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/CHEBI_27773_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/5a7a9c60-7a0e-447a-acbb-734a4b9be374_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/52f15c9b-5c22-4cd7-9fc2-83c459fde5ce_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> , <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2092,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2106,27 +2164,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_15379>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002233_d7f17ae9-e907-411b-9a27-9ac1bdfb864c_ENOYL-COA-DELTA-ISOM-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_77332_ACYLCOASYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_77332> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002234_5efa3fcd-e059-4180-b745-04245e0c2b08_KETOACYLCOATHIOL-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004274>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2139,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2155,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2169,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,20 +2252,20 @@
           <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
 ] .
 
-<http://model.geneontology.org/8426423b-fc60-4ac8-a9a1-0d610cf4581a_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/CHEBI_77332_KETOACYLCOATHIOL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_77332> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (3Z)-alk-3-enoyl-CoA" ;
+                "a 2,3,4-saturated fatty acyl CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2221,28 +2274,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -2253,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2266,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2280,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2310,7 +2346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,7 +2365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2349,9 +2385,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11026_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_RXN-11026> , <http://model.geneontology.org/8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN-11026> , <http://model.geneontology.org/CHEBI_77332_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16240_RXN-11026> , <http://model.geneontology.org/1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-11026> , <http://model.geneontology.org/68807a3d-8d26-46ea-87eb-244522db6552_RXN-11026> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL205W-MONOMER_RXN-11026_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2359,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2367,23 +2403,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_1015a147-03b7-4561-bcbd-57cd24a77cd6_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_CHEBI_29888_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2408,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2427,7 +2452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2443,18 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002411_RXN-11026_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2465,7 +2479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2478,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2486,23 +2500,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_8e027dc0-374d-4782-bd92-36cebcd5af59_ACYLCOASYN-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_15378_OHACYL-COA-DEHYDROG-RXN_SGD_PWY_YeastPathways_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YeastPathways_YEAST-GALACT-METAB-PWY.ttl
+++ b/models/YeastPathways_YEAST-GALACT-METAB-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,6 +547,28 @@
           <http://model.geneontology.org/CHEBI_58885_UDPGLUCEPIM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/YBR018C-MONOMER_GALACTURIDYLYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000000222> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -554,35 +576,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYProtein27469> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000050_YeastPathways_YEAST-GALACT-METAB-PWY/YeastPathways_YEAST-GALACT-METAB-PWY_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GALACTOKIN-RXN_RO_0002413_GALACTURIDYLYLTRANS-RXN_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004614>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -918,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1091,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1122,7 +1122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1362,24 +1362,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYBiochemicalReaction27472> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000066_reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -1390,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "galactose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1398,12 +1387,23 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_BFO_0000066_reaction_ALDOSE1EPIM-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ALDOSE1EPIM-RXN_RO_0002333_YBR019C-MONOMER_ALDOSE1EPIM-RXN_controller_SGD_PWY_YeastPathways_YEAST-GALACT-METAB-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1508,7 +1508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1568,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1598,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1643,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1659,7 +1659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_YEAST-RIBOSYN-PWY.ttl
+++ b/models/YeastPathways_YEAST-RIBOSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,15 +27,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_30616_RIBOFLAVINKIN-RXN>
 ] .
-
-<http://model.geneontology.org/reaction_RXN3O-110_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/GTP-CYCLOHYDRO-II-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003935> ;
@@ -56,13 +47,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYBiochemicalReaction53920> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/reaction_RXN3O-110_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -425,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,17 +761,6 @@
           <http://model.geneontology.org/CHEBI_29114_GTP-CYCLOHYDRO-II-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002234_CHEBI_15934_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
@@ -780,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,6 +780,17 @@
           <http://model.geneontology.org/CHEBI_15934_RIBOPHOSPHAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-164_RO_0002234_CHEBI_15934_RXN3O-164_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
@@ -799,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -896,29 +896,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58890>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_57540_RXN-10057>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53841> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-164>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -939,13 +922,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYBiochemicalReaction53901> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_57540_RXN-10057>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53841> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58201_LUMAZINESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58201> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1040,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1118,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1154,7 +1154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1218,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,18 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,12 +1259,23 @@
           <http://model.geneontology.org/CHEBI_30616_FADSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RIBOPHOSPHAT-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_FADSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1320,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1414,7 +1414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1485,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1524,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1556,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1603,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1619,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,7 +1688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1708,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1738,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1880,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2022,7 +2022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2037,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2059,7 +2059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,7 +2100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2114,7 +2114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2130,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,7 +2163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2208,7 +2208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2268,7 +2268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2287,7 +2287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2314,7 +2314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2322,25 +2322,6 @@
 
 <http://identifiers.org/sgd/S000005503>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002234_CHEBI_58890_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-110> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58890_RXN3O-110>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_LUMAZINESYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2351,13 +2332,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RIBOSYN-PWYSmallMolecule53879> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-110_RO_0002234_CHEBI_58890_RXN3O-110_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-110> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58890_RXN3O-110>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2370,7 +2370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2407,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,7 +2423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2461,7 +2461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2472,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2483,7 +2483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2497,7 +2497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2508,17 +2508,6 @@
           <http://model.geneontology.org/LUMAZINESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN-10058>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2528,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2544,7 +2533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,6 +2544,17 @@
           <http://model.geneontology.org/CHEBI_58890_RXN-10057>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-110_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_50606_DIOHBUTANONEPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_50606> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2564,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2580,7 +2580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2610,7 +2610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,7 +2630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "riboflavin, FMN and FAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2643,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2657,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,7 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2693,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2710,7 +2710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2732,7 +2732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2762,7 +2762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2778,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2797,7 +2797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2811,7 +2811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2830,7 +2830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2841,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2855,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2869,7 +2869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2885,7 +2885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2898,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2914,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2941,7 +2941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2953,7 +2953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2973,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2989,7 +2989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3019,23 +3019,23 @@
           <http://model.geneontology.org/YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY>
 ] .
 
-<http://model.geneontology.org/reaction_RXN-10058_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_LUMAZINESYN-RXN_RO_0002413_RIBOFLAVIN-SYN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN-10058_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3044,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3059,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3084,7 +3084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3097,7 +3097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3112,7 +3112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3128,7 +3128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3144,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3157,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3173,7 +3173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3192,7 +3192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,7 +3208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3219,7 +3219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3233,7 +3233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3253,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3269,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3287,7 +3287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3303,7 +3303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3325,7 +3325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3344,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3358,7 +3358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3377,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3411,7 +3411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3430,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3438,6 +3438,17 @@
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_30616_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58890_RXN-10057>
         a       <http://purl.obolibrary.org/obo/CHEBI_58890> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3448,7 +3459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3456,23 +3467,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBOFLAVINKIN-RXN_RO_0002233_CHEBI_30616_RIBOFLAVINKIN-RXN_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-RIBOSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RIBOFLAVIN-SYN-RXN_BFO_0000050_YeastPathways_YEAST-RIBOSYN-PWY/YeastPathways_YEAST-RIBOSYN-PWY_SGD_PWY_YeastPathways_YEAST-RIBOSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3497,7 +3497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3513,7 +3513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3529,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3543,7 +3543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3559,7 +3559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3573,7 +3573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3592,7 +3592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3608,7 +3608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3625,7 +3625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3645,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3691,7 +3691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3705,7 +3705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3735,7 +3735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3754,7 +3754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3782,7 +3782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3798,7 +3798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3809,7 +3809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3837,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3848,7 +3848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3863,7 +3863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3879,7 +3879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3901,7 +3901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3917,7 +3917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3931,7 +3931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3953,7 +3953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3990,7 +3990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4004,7 +4004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4022,7 +4022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YeastPathways_YEAST-RNT-SALV.ttl
+++ b/models/YeastPathways_YEAST-RNT-SALV.ttl
@@ -9,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,18 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +591,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_URIDINE-NUCLEOSIDASE-RXN_BFO_0000050_YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV_SGD_PWY_YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,7 +811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -886,7 +886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -975,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1324,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1368,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1393,7 +1393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1426,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1448,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1465,7 +1465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1557,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1578,6 +1578,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/reaction_RXN-11832_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
@@ -1586,7 +1595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,15 +1605,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YDR400W-MONOMER_URIDINE-NUCLEOSIDASE-RXN_controller>
 ] .
-
-<http://model.geneontology.org/reaction_RXN-11832_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1617,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1749,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1790,7 +1790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,7 +1809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,11 +1825,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
+
+<http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0010138> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "Pyrimidine nucleotides are essential as components of nucleic acids, as substrates for amino acid synthesis and as energy sources, but defects in the de novo biosynthesis of pyrimidines are not lethal in S. cerevisiae cells |CITS:10501935|. This is because salvage pathways are able to utilize preformed bases (either from exogenous sources or internal turnover sources) for the synthesis of pyrimidines |CITS:2189783|. If the required substrates are available, salvage pathways are preferred over de novo synthesis pathways for pyrimidine biosynthesis |CITS:12111094|. The salvage pathways of pyrimidine ribonucleotides consist of 1) importing exogenous bases into the cell, and 2) the interconversion of various bases |CITS:2189783||CITS:12111094|. Three proteins are involved in the import of exogenous bases used by the salvage pathway for pyrimidine ribonucleotide biosynthesis. Uracil enters the cell via the Fur4p uracil permease |CITS:6290876||CITS:3276521|, cytosine enters the cell via the Fcy2p purine-cytosine transporter |CITS:6387700||CITS:2191181|, and uridine enters the cell via the Fui1p uridine permease |CITS:9485596|. As with many of the metabolic pathways of S. cerevisiae, the pathways for the salvage of pyrimidine ribonucleotides are under both transcriptional and post-transcriptional catabolite repression at a variety of points |CITS:10074071||CITS:11125145||CITS:12111094||CITS:12570998||CITS:12791685||CITS:1429716||CITS:14657252|. This pathway is of biomedical interest because cytosine deaminase (Fcy1p) is not found in mammals |CITS:12637534| and is capable of catalyzing the deamination of the prodrug 5-fluorocytosine (5FC) to form the anticancer drug 5-fluorouracil (5FU) |CITS:15823054|. Expression of Fcy1p in tumor cells increases their sensitivity to 5FC, and expression of Fur1p increases tumor cell sensitivity to 5FU |CITS:10919655|. Tumor cells expressing a novel chimeric protein, produced from a gene containing the FCY1 and FUR1 coding sequences fused in frame, display significantly increased sensitivity to 5-FC suggesting that this novel suicide gene may constitute an original and potent candidate therapeutic gene for cancer gene therapy |CITS:10919655|." ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "salvage pathways of pyrimidine ribonucleotides" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "YeastPathways_YEAST-RNT-SALV" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1839,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1855,28 +1872,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-<http://model.geneontology.org/YeastPathways_YEAST-RNT-SALV/YeastPathways_YEAST-RNT-SALV>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0010138> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "Pyrimidine nucleotides are essential as components of nucleic acids, as substrates for amino acid synthesis and as energy sources, but defects in the de novo biosynthesis of pyrimidines are not lethal in S. cerevisiae cells |CITS:10501935|. This is because salvage pathways are able to utilize preformed bases (either from exogenous sources or internal turnover sources) for the synthesis of pyrimidines |CITS:2189783|. If the required substrates are available, salvage pathways are preferred over de novo synthesis pathways for pyrimidine biosynthesis |CITS:12111094|. The salvage pathways of pyrimidine ribonucleotides consist of 1) importing exogenous bases into the cell, and 2) the interconversion of various bases |CITS:2189783||CITS:12111094|. Three proteins are involved in the import of exogenous bases used by the salvage pathway for pyrimidine ribonucleotide biosynthesis. Uracil enters the cell via the Fur4p uracil permease |CITS:6290876||CITS:3276521|, cytosine enters the cell via the Fcy2p purine-cytosine transporter |CITS:6387700||CITS:2191181|, and uridine enters the cell via the Fui1p uridine permease |CITS:9485596|. As with many of the metabolic pathways of S. cerevisiae, the pathways for the salvage of pyrimidine ribonucleotides are under both transcriptional and post-transcriptional catabolite repression at a variety of points |CITS:10074071||CITS:11125145||CITS:12111094||CITS:12570998||CITS:12791685||CITS:1429716||CITS:14657252|. This pathway is of biomedical interest because cytosine deaminase (Fcy1p) is not found in mammals |CITS:12637534| and is capable of catalyzing the deamination of the prodrug 5-fluorocytosine (5FC) to form the anticancer drug 5-fluorouracil (5FU) |CITS:15823054|. Expression of Fcy1p in tumor cells increases their sensitivity to 5FC, and expression of Fur1p increases tumor cell sensitivity to 5FU |CITS:10919655|. Tumor cells expressing a novel chimeric protein, produced from a gene containing the FCY1 and FUR1 coding sequences fused in frame, display significantly increased sensitivity to 5-FC suggesting that this novel suicide gene may constitute an original and potent candidate therapeutic gene for cancer gene therapy |CITS:10919655|." ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "salvage pathways of pyrimidine ribonucleotides" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "YeastPathways_YEAST-RNT-SALV" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1886,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1922,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1988,7 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2003,30 +2003,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46617> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/URIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004849> ;
@@ -2045,13 +2028,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVBiochemicalReaction46583> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46617> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_RXN-11832>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -2062,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2096,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2129,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,7 +2167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2183,7 +2183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2194,7 +2194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2209,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2225,7 +2225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2244,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2291,7 +2291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2310,7 +2310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2326,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2339,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2357,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2376,7 +2376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2413,7 +2413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2432,7 +2432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2457,7 +2457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2474,7 +2474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,7 +2490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2501,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2516,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2529,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2543,7 +2543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2562,7 +2562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2578,7 +2578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2592,7 +2592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2611,7 +2611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2627,7 +2627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2638,7 +2638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2649,7 +2649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2664,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2677,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2692,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2709,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,7 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2736,7 +2736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2755,7 +2755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2780,7 +2780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2800,7 +2800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2813,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2822,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2836,7 +2836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2857,7 +2857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2873,7 +2873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2892,7 +2892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2945,7 +2945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3014,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3025,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3039,7 +3039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3055,7 +3055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3070,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3086,7 +3086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3120,7 +3120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3136,7 +3136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3150,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,7 +3170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3183,7 +3183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3194,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3205,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3216,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3237,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3254,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3270,7 +3270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3289,7 +3289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3309,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3325,7 +3325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3341,7 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -3362,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3378,7 +3378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3389,7 +3389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3404,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3417,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3431,7 +3431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YeastPathways_YEAST-SALV-PYRMID-DNTP.ttl
+++ b/models/YeastPathways_YEAST-SALV-PYRMID-DNTP.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -125,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -144,7 +144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -618,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,12 +634,23 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_57566_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "GOC:sgd_curators" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2023-08-10" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "http://www.yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -649,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,17 +671,6 @@
           <http://model.geneontology.org/YeastPathways_YEAST-SALV-PYRMID-DNTP/YeastPathways_YEAST-SALV-PYRMID-DNTP>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_57566_RXN-14093_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "GOC:sgd_curators" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "http://www.yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -987,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1109,14 +1109,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
 <http://model.geneontology.org/THYKI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
+        a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "thymidine + ATP &rarr; dTMP + ADP + H<SUP>+</SUP>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1210,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1430,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1459,7 +1459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1562,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,30 +1595,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000066_reaction_THYKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "GOC:sgd_curators" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
-  <http://purl.org/pav/providedBy>
-          "http://www.yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/THYKI-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_THYKI-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_16450_CYTIDEAM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16450> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1629,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,13 +1620,32 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" , "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_THYKI-RXN_BFO_0000066_reaction_THYKI-RXN_location_lociGO_0005829_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "GOC:sgd_curators" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2023-08-10" ;
+  <http://purl.org/pav/providedBy>
+          "http://www.yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/THYKI-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_THYKI-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
           "Imported from Saccharomyces Genome Database: https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002233_CHEBI_16450_CYTIDEAM-RXN_SGD_PWY_YeastPathways_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1729,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1850,7 +1850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1864,7 +1864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1883,7 +1883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1968,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1993,7 +1993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,7 +2013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2044,7 +2044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,7 +2080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2119,7 +2119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2135,7 +2135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2151,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2165,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2185,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2254,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2266,7 +2266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2285,7 +2285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,7 +2331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2342,7 +2342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" .
 
@@ -2369,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2385,7 +2385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2415,7 +2415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "GOC:sgd_curators" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2023-05-25" ;
+          "2023-08-10" ;
   <http://purl.org/pav/providedBy>
           "http://www.yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD_PWY:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2491,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2506,7 +2506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "GOC:sgd_curators" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2023-05-25" ;
+                "2023-08-10" ;
         <http://purl.org/pav/providedBy>
                 "http://www.yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>


### PR DESCRIPTION
Full regen of 220 models after plugging in lookup tables for UniProt->SGD and CHEBI conversions. For geneontology/pathways2GO#269.